### PR TITLE
Fix spelling of SUSE

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -71,7 +71,7 @@ crypt.h: crypt-base.h gen-crypt-h.awk config.h
 	$(AM_V_at)mv -f crypt.h.T crypt.h
 
 # When we are being binary compatible, also install symbolic links to
-# mimic SuSE's libowcrypt; any program that uses -lowcrypt in its
+# mimic SUSE's libowcrypt; any program that uses -lowcrypt in its
 # build, or already has a NEEDED entry for libowcrypt.so.1, will be
 # redirected to libcrypt.  The OW_CRYPT_1.0 symbol versions are already
 # present in libcrypt.so.1.
@@ -80,7 +80,7 @@ crypt.h: crypt-base.h gen-crypt-h.awk config.h
 # libraries involved, libcrypt.so.1 and libowcrypt.so.1.  (We should
 # be able to get away with this because in any circumstance where the
 # soname of libcrypt isn't libcrypt.so.1, ENABLE_OBSOLETE_API should
-# be automatically turned off, and as best I can tell, SuSE only ever
+# be automatically turned off, and as best I can tell, SUSE only ever
 # shipped libowcrypt.so.1.)
 if ENABLE_OBSOLETE_API
 if ENABLE_STATIC

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ libcrypt.so.1.  We have taken pains to provide exactly the same
 "symbol versions" as were used by glibc on various CPU architectures,
 and to account for the variety of ways in which the Openwall
 extensions were patched into glibc's libcrypt by some Linux
-distributions.  (For instance, compatibility symlinks for SuSE's
+distributions.  (For instance, compatibility symlinks for SUSE's
 "libowcrypt" are provided.)
 
 However, the converse is not true: programs linked against libxcrypt

--- a/libcrypt.map.in
+++ b/libcrypt.map.in
@@ -7,7 +7,7 @@ crypt			XCRYPT_2.0	GLIBC_2.0
 crypt_r			XCRYPT_2.0	GLIBC_2.0
 
 # Actively supported Openwall extensions; never actually added to
-# upstream GNU libc, but present in at least Openwall, ALT, and SuSE
+# upstream GNU libc, but present in at least Openwall, ALT, and SUSE
 # Linux distributions with one or more of these symbol versions
 crypt_rn		XCRYPT_2.0	GLIBC_2.0	GLIBC_2.2.1
 crypt_gensalt		XCRYPT_2.0	GLIBC_2.0	GLIBC_2.2.1     OW_CRYPT_1.0


### PR DESCRIPTION
The lower 'u' in SUSE was gone 14 years ago.