### PR TITLE
crypt_gensalt_ra: Avoid memory leak in case of crypt_gensalt_rn error

### DIFF
--- a/crypt.c
+++ b/crypt.c
@@ -412,8 +412,11 @@ crypt_gensalt_ra (const char *prefix, unsigned long count,
   if (!output)
     return 0;
 
-  return crypt_gensalt_rn (prefix, count, rbytes, nrbytes, output,
-                           CRYPT_GENSALT_OUTPUT_SIZE);
+  char *result = crypt_gensalt_rn (prefix, count, rbytes, nrbytes, output,
+                                   CRYPT_GENSALT_OUTPUT_SIZE);
+  if (result == 0)
+    free (output);
+  return result;
 }
 SYMVER_crypt_gensalt_ra;
 #endif


### PR DESCRIPTION
This was reported by clang.

```
Error: CLANG_WARNING: [#def6]
libxcrypt-4.1.0/crypt.c:415:3: warning: Potential leak of memory pointed to by 'output'
#  return crypt_gensalt_rn (prefix, count, rbytes, nrbytes, output,
#  ^
libxcrypt-4.1.0/crypt.c:411:18: note: Memory is allocated
#  char *output = malloc (CRYPT_GENSALT_OUTPUT_SIZE);
#                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libxcrypt-4.1.0/crypt.c:412:7: note: Assuming 'output' is non-null
#  if (!output)
#      ^~~~~~~
libxcrypt-4.1.0/crypt.c:412:3: note: Taking false branch
#  if (!output)
#  ^
libxcrypt-4.1.0/crypt.c:415:3: note: Potential leak of memory pointed to by 'output'
#  return crypt_gensalt_rn (prefix, count, rbytes, nrbytes, output,
#  ^
#  413|       return 0;
#  414|   
#  415|->   return crypt_gensalt_rn (prefix, count, rbytes, nrbytes, output,
#  416|                              CRYPT_GENSALT_OUTPUT_SIZE);
#  417|   }
```