### PR TITLE
Fix multiple definition issue with old versions of GNU ld

### DIFF
--- a/crypt-port.h
+++ b/crypt-port.h
@@ -129,8 +129,8 @@ void _xcrypt_secure_memset (void *s, size_t len)
 
 /* Set the symbol version for EXTNAME, which uses INTNAME as its
    implementation.  */
-#define symver_set(extname, intname, version, mode) \
-  __asm__ (".symver " #intname "," #extname mode #version)
+#define symver_set(extstr, intname, version, mode) \
+  __asm__ (".symver " #intname "," extstr mode #version)
 
 /* A construct with the same syntactic role as the expansion of symver_set,
    but which does nothing.  */
@@ -165,22 +165,22 @@ void _xcrypt_secure_memset (void *s, size_t len)
 
 #ifdef PIC
 
-#define symver_compat(n, extname, intname, version) \
+#define symver_compat(n, extstr, extname, intname, version) \
   strong_alias (intname, extname ## __ ## n); \
-  symver_set (extname, extname ## __ ## n, version, "@")
+  symver_set (extstr, extname ## __ ## n, version, "@")
 
-#define symver_compat0(extname, intname, version) \
-  symver_set (extname, intname, version, "@")
+#define symver_compat0(extstr, intname, version) \
+  symver_set (extstr, intname, version, "@")
 
-#define symver_default(extname, intname, version) \
-  symver_set (extname, intname, version, "@@")
+#define symver_default(extstr, intname, version) \
+  symver_set (extstr, intname, version, "@@")
 
 #else
 
 /* When not building the shared library, don't do any of this.  */
-#define symver_compat(n, extname, intname, version) symver_nop ()
-#define symver_compat0(extname, intname, version) symver_nop ()
-#define symver_default(extname, intname, version) symver_nop ()
+#define symver_compat(n, extstr, extname, intname, version) symver_nop ()
+#define symver_compat0(extstr, intname, version) symver_nop ()
+#define symver_default(extstr, intname, version) symver_nop ()
 
 #endif
 #endif
@@ -188,8 +188,8 @@ void _xcrypt_secure_memset (void *s, size_t len)
 /* Tests may need to _refer_ to compatibility symbols, but should never need
    to _define_ them.  */
 
-#define symver_ref(extname, intname, version) \
-  symver_set(extname, intname, version, "@")
+#define symver_ref(extstr, intname, version) \
+  symver_set(extstr, intname, version, "@")
 
 /* Get the set of hash algorithms to be included and some related
    definitions.  */

--- a/gen-vers.awk
+++ b/gen-vers.awk
@@ -172,16 +172,20 @@ END {
 
     for (sym in allsyms) {
         if (includesym[sym]) {
-            printf("#define SYMVER_%s \\\n", sym)
             seq = 0
             for (i = NVCHAIN; i >= symver_floor_idx; i--) {
                 v = VCHAIN[i]
                 if ((v, sym) in symset) {
                     if (seq == 0) {
+                        if (compat_only[sym] || includesym[sym] > 1) {
+                            printf("#ifdef PIC\n#define %s _crypt_%s\n#endif\n",
+                                   sym, sym);
+                        }
+                        printf("#define SYMVER_%s \\\n", sym)
                         if (compat_only[sym]) {
-                            printf("  symver_compat0 (%s, %s, %s)", sym, sym, v)
+                            printf("  symver_compat0 (\"%s\", %s, %s)", sym, sym, v)
                         } else if (includesym[sym] > 1) {
-                            printf("  symver_default (%s, %s, %s)", sym, sym, v)
+                            printf("  symver_default (\"%s\", %s, %s)", sym, sym, v)
                         } else {
                             # Due to what appears to be a bug in GNU ld,
                             # we must not issue symver_default() if there
@@ -189,8 +193,8 @@ END {
                             printf("  symver_nop ()")
                         }
                     } else {
-                        printf("; \\\n  symver_compat (%d, %s, %s, %s)",
-                               seq, sym, sym, v)
+                        printf("; \\\n  symver_compat (%d, \"%s\", %s, %s, %s)",
+                               seq, sym, sym, sym, v)
                     }
                     seq++
                 }

--- a/test-des-obsolete.c
+++ b/test-des-obsolete.c
@@ -13,8 +13,8 @@
 
 #include <stdio.h>
 
-symver_ref(encrypt, encrypt, SYMVER_FLOOR);
-symver_ref(setkey, setkey, SYMVER_FLOOR);
+symver_ref("encrypt", encrypt, SYMVER_FLOOR);
+symver_ref("setkey", setkey, SYMVER_FLOOR);
 
 static void
 expand (unsigned char ex[64], const unsigned char pk[8])

--- a/test-des-obsolete_r.c
+++ b/test-des-obsolete_r.c
@@ -13,8 +13,8 @@
 
 #include <stdio.h>
 
-symver_ref(encrypt_r, encrypt_r, SYMVER_FLOOR);
-symver_ref(setkey_r, setkey_r, SYMVER_FLOOR);
+symver_ref("encrypt_r", encrypt_r, SYMVER_FLOOR);
+symver_ref("setkey_r", setkey_r, SYMVER_FLOOR);
 
 static void
 expand (unsigned char ex[64], const unsigned char pk[8])


### PR DESCRIPTION
Workaround the following bug in GNU ld version <= 2.26.2:

	$ cat symver.c
	int fun(int i) {return i;}
	__asm__(".symver fun,fun@@V1");
	extern __typeof__(fun) fun0 __attribute__((__alias__("fun")));
	__asm__(".symver fun0,fun@V0");

	$ cat symver.map
	V0 { global: fun; local: *; };
	V1 { global: fun; local: *; } V0;

	$ gcc -g -Wall -O2 -fPIC -DPIC -c symver.c
	$ gcc -fPIC -shared -Wl,--version-script=symver.map symver.o
	symver.o: In function `fun':
	symver.c:1: multiple definition of `fun'
	symver.o:symver.c:1: first defined here
	collect2: error: ld returned 1 exit status