### PR TITLE
Issue #16: allow explicit rounds=<default> in sunmd5,sha256,sha512.

### DIFF
--- a/crypt-sha256.c
+++ b/crypt-sha256.c
@@ -111,6 +111,7 @@ crypt_sha256_rn (const char *phrase, const char *setting,
   size_t cnt;
   /* Default number of rounds.  */
   size_t rounds = ROUNDS_DEFAULT;
+  bool rounds_custom = false;
 
   /* Find beginning of salt string.  The prefix should normally always
      be present.  Just in case it is not.  */
@@ -136,13 +137,13 @@ crypt_sha256_rn (const char *phrase, const char *setting,
       if (endp == num || *endp != '$'
           || rounds < ROUNDS_MIN
           || rounds > ROUNDS_MAX
-          || rounds == ROUNDS_DEFAULT
           || errno)
         {
           errno = EINVAL;
           return;
         }
       salt = endp + 1;
+      rounds_custom = true;
     }
 
   salt_len = strspn (salt, b64t);
@@ -255,7 +256,7 @@ crypt_sha256_rn (const char *phrase, const char *setting,
   memcpy (cp, sha256_salt_prefix, sizeof (sha256_salt_prefix) - 1);
   cp += sizeof (sha256_salt_prefix) - 1;
 
-  if (rounds != ROUNDS_DEFAULT)
+  if (rounds_custom)
     {
       int n = snprintf (cp,
                         SHA256_HASH_LENGTH - (sizeof (sha256_salt_prefix) - 1),

--- a/crypt-sha512.c
+++ b/crypt-sha512.c
@@ -111,6 +111,7 @@ crypt_sha512_rn (const char *phrase, const char *setting,
   size_t cnt;
   /* Default number of rounds.  */
   size_t rounds = ROUNDS_DEFAULT;
+  bool rounds_custom = false;
 
   /* Find beginning of salt string.  The prefix should normally always
      be present.  Just in case it is not.  */
@@ -136,13 +137,13 @@ crypt_sha512_rn (const char *phrase, const char *setting,
       if (endp == num || *endp != '$'
           || rounds < ROUNDS_MIN
           || rounds > ROUNDS_MAX
-          || rounds == ROUNDS_DEFAULT
           || errno)
         {
           errno = EINVAL;
           return;
         }
       salt = endp + 1;
+      rounds_custom = true;
     }
 
   salt_len = strspn (salt, b64t);
@@ -258,7 +259,7 @@ crypt_sha512_rn (const char *phrase, const char *setting,
   memcpy (cp, sha512_salt_prefix, sizeof (sha512_salt_prefix) - 1);
   cp += sizeof (sha512_salt_prefix) - 1;
 
-  if (rounds != ROUNDS_DEFAULT)
+  if (rounds_custom)
     {
       int n = snprintf (cp,
                         SHA512_HASH_LENGTH - (sizeof (sha512_salt_prefix) - 1),

--- a/test-crypt-sha256.c
+++ b/test-crypt-sha256.c
@@ -16,6 +16,11 @@ static const struct
     "$5$saltstring", "Hello world!",
     "$5$saltstring$5B8vYYiY.CVt1RlTTf8KbXBH3hsxY/GNooZaBBGWEc5"
   },
+  /* explicit specification of rounds=5000 should be allowed and preserved */
+  {
+    "$5$rounds=5000$saltstring", "Hello world!",
+    "$5$rounds=5000$saltstring$5B8vYYiY.CVt1RlTTf8KbXBH3hsxY/GNooZaBBGWEc5"
+  },
   {
     "$5$rounds=10000$saltstringsaltstring", "Hello world!",
     "$5$rounds=10000$saltstringsaltst$3xv.VbSHBb41AL9AvLeujZkZRBAwqFMz2."

--- a/test-crypt-sha512.c
+++ b/test-crypt-sha512.c
@@ -17,6 +17,12 @@ static const struct
     "$6$saltstring$svn8UoSVapNtMuq1ukKS4tPQd8iKwSMHWjl/O817G3uBnIFNjnQJu"
     "esI68u4OTLiBFdcbYEdFCoEOfaS35inz1"
   },
+  /* explicit specification of rounds=5000 should be allowed and preserved */
+  {
+    "$6$rounds=5000$saltstring", "Hello world!",
+    "$6$rounds=5000$saltstring$svn8UoSVapNtMuq1ukKS4tPQd8iKwSMHWjl/O817G3"
+    "uBnIFNjnQJuesI68u4OTLiBFdcbYEdFCoEOfaS35inz1"
+  },
   {
     "$6$rounds=10000$saltstringsaltstring", "Hello world!",
     "$6$rounds=10000$saltstringsaltst$OW1/O6BYHV6BcXZu8QVeXbDWra3Oeqh0sb"

--- a/test-crypt-sunmd5.c
+++ b/test-crypt-sunmd5.c
@@ -54,6 +54,11 @@ const char *tests[][3] =
     "$md5$1xMeE.at$qRpVD46c.sEWM/48tNk191"
   },
   {
+    "$md5,rounds=4096$1xMeE.at$$XbkZGZUTKzh/i0o7JRKe./",
+    "$md5,rounds=4096$1xMeE.at$",
+    "$md5,rounds=4096$1xMeE.at$XbkZGZUTKzh/i0o7JRKe./",
+  },
+  {
     "$md5,rounds=9748$2kkhnoZI$$HzOCKmX2sus/1S9CmohBY/",
     "$md5,rounds=9748$2kkhnoZI$",
     "$md5,rounds=9748$2kkhnoZI$HzOCKmX2sus/1S9CmohBY/"


### PR DESCRIPTION
This partially reverts 15d1e3bf3d259ea262f3d34e8c225a3abfabaa09 and
adds test cases to cover the scenario at stake.