### PR TITLE
Remove sha256crypt ($5$) and sha512crypt ($6$) from strong set.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,10 @@ Version 4.2.0
 * --enable-hashes now supports additional groups of hashing methods:
   'altlinux', 'owl', and 'suse', which select the methods historically
   supported on those operating systems.
+* --enable-hashes=strong now excludes the SHA-2-based hashes
+  ($5$ and $6$).  These are still cryptographically sound, but not
+  hardened against massively parallel brute-force attacks (e.g. using
+  GPUs to compute SHA-2) as the newer bcrypt, scrypt, and yescrypt are.
 
 Version 4.1.2
 * Add optional 'check-valgrind' target to the Makefile.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ supported hashes.  Disabling the traditional ‘des’ hash algorithm
 implies `--disable-obsolete-api`.  Security-conscious environments
 without backward compatibility constraints are encouraged to use
 `--enable-hashes=strong`, which enables only the hash functions that
-are strong enough to be safe for newly hashed passwords.
+are definitely strong enough to be safe for newly hashed passwords.
 
 The original implementation of the SUNMD5 hashing algorithm has a bug,
 which is mimicked by libxcrypt to be fully compatible with hashes

--- a/crypt.5
+++ b/crypt.5
@@ -166,6 +166,7 @@ originally for the Tarsnap online backup service.
 The algorithm was specifically designed to make it costly to perform
 large-scale custom hardware attacks by requiring large amounts of memory.
 In 2016, the scrypt algorithm was published by IETF as RFC 7914.
+Not as strong as yescrypt, but still acceptable for new hashes.
 .hash "$7$" "\e$7\e$[./A-Za-z0-9]{11,97}\e$[./A-Za-z0-9]{43}" unlimited 8 256 256 "up to 512" "6 to 11 (logarithmic)"
 .PP
 .ti -4
@@ -176,6 +177,7 @@ modified to have an extra-expensive key schedule.
 Originally developed by Niels Provos and David Mazieres for OpenBSD
 and also supported on recent versions of FreeBSD and NetBSD,
 on Solaris 10 and newer, and on several GNU/*/Linux distributions.
+Not as strong as yescrypt, but still acceptable for new hashes.
 .hash "$2b$" "\e$2[abxy]\e$[0-9]{2}\e$[./A-Za-z0-9]{53}" 72 8 184 184 128 "4 to 31 (logarithmic)"
 .PP
 The alternative prefix "$2y$" is equivalent to "$2b$".
@@ -190,7 +192,7 @@ which incorrectly processed characters with the 8th bit set.
 A hash based on SHA-2 with 512-bit output,
 originally developed by Ulrich Drepper for GNU libc.
 Supported on Linux but not common elsewhere.
-Acceptable for new hashes.
+Not recommended for new hashes, but not catastrophically weak.
 The default CPU time cost parameter is 5000,
 which is too low for modern hardware.
 .br
@@ -202,7 +204,7 @@ which is too low for modern hardware.
 A hash based on SHA-2 with 256-bit output,
 originally developed by Ulrich Drepper for GNU libc.
 Supported on Linux but not common elsewhere.
-Acceptable for new hashes.
+Not recommended for new hashes, but not catastrophically weak.
 The default CPU time cost parameter is 5000,
 which is too low for modern hardware.
 .br

--- a/hashes.lst
+++ b/hashes.lst
@@ -34,8 +34,8 @@ bcrypt   _a         $2a$      16       STRONG,ALTLINUX,FREEBSD,NETBSD,OPENBSD,OW
 bcrypt   _b         $2b$      16       STRONG,ALTLINUX,FREEBSD,NETBSD,OPENBSD,OWL,SOLARIS,SUSE
 bcrypt   _x         $2x$      16       STRONG,ALTLINUX,FREEBSD,NETBSD,OPENBSD,OWL,SOLARIS,SUSE
 bcrypt   _y         $2y$      16       STRONG,ALTLINUX,FREEBSD,NETBSD,OPENBSD,OWL,SOLARIS,SUSE
-sha512   :          $6$       15       STRONG,GLIBC,FREEBSD,SOLARIS
-sha256   :          $5$       15       STRONG,GLIBC,FREEBSD,SOLARIS
+sha512   :          $6$       15       GLIBC,FREEBSD,SOLARIS
+sha256   :          $5$       15       GLIBC,FREEBSD,SOLARIS
 md5      :          $1$       9        GLIBC,FREEBSD,NETBSD,OPENBSD,SOLARIS
 sunmd5   :          $md5      8        SOLARIS
 sha1     :          $sha1     20       NETBSD


### PR DESCRIPTION
These are the strongest hashes supported by glibc’s libcrypt, but
they have no particular protection against hardware parallel
attacks (e.g. using GPUs to iterate SHA-2) and should probably
only be used for new hashes in mixed environments where yescrypt
and/or bcrypt aren’t universally supported.

It’s difficult to find information about how difficult these hashes
specifically are to brute-force; the big online services whose user
databases got dumped seem to have skipped straight from SHA-1 or worse
straight to bcrypt.  I think what I said in NEWS is accurate as far as
it goes, but it might be nice to add more concrete numbers and advice
to crypt.5.