### PR TITLE
Convert existing manpages to BSD mdoc format.

### DIFF
--- a/crypt.3
+++ b/crypt.3
@@ -1,426 +1,468 @@
 .\" Written and revised by Solar Designer <solar at openwall.com> in 2000-2011.
 .\" Revised by Zack Weinberg <zackw at panix.com> in 2017.
+.\" Converted to mdoc format by Zack Weinberg in 2018.
 .\"
 .\" No copyright is claimed, and this man page is hereby placed in the public
 .\" domain.  In case this attempt to disclaim copyright and place the man page
 .\" in the public domain is deemed null and void, then the man page is
-.\" Copyright 2000-2011 Solar Designer, 2017 Zack Weinberg, and it is
- \" hereby released to the general public under the following terms:
+.\" Copyright 2000-2011 Solar Designer, 2017, 2018 Zack Weinberg, and it is
+.\" hereby released to the general public under the following terms:
 .\"
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted.
 .\"
 .\" There's ABSOLUTELY NO WARRANTY, express or implied.
 .\"
-.\" This manual page in its current form is intended for use on systems
-.\" based on the GNU C Library with crypt_blowfish patched into libcrypt.
-.\"
-.TH CRYPT_RN 3 "October 11, 2017" "Openwall Project" "Library functions"
-.ad l
-.\" No macros in NAME to keep makewhatis happy.
-.SH NAME
-\fBcrypt\fR, \fBcrypt_r\fR, \fBcrypt_rn\fR, \fBcrypt_ra\fR
-\- passphrase hashing
-.SH SYNOPSIS
-.B #include <crypt.h>
-.sp
-.in +8
-.ti -8
-.BI "char *crypt(const char *" phrase ", const char *" setting );
-.ti -8
-.BI "char *crypt_r(const char *" phrase ", const char *" setting ", struct crypt_data *" data );
-.ti -8
-.BI "char *crypt_rn(const char *" phrase ", const char *" setting ", void *" data ", int " size );
-.ti -8
-.BI "char *crypt_ra(const char *" phrase ", const char *" setting ", void **" data ", int *" size );
-.in -8
-.sp
-Link with
-.IR -lcrypt .
-.ad b
-.SH DESCRIPTION
+.Dd October 11, 2017
+.Dt CRYPT 3
+.Os "Openwall Project"
+.Sh NAME
+.Nm crypt , crypt_r , crypt_rn , crypt_ra
+.Nd passphrase hashing
+.Sh LIBRARY
+.Lb libcrypt
+.Sh SYNOPSIS
+.In crypt.h
+.Ft "char *"
+.Fo crypt
+.Fa "const char *phrase"
+.Fa "const char *setting"
+.Fc
+.Ft "char *"
+.Fo crypt_r
+.Fa "const char *phrase"
+.Fa "const char *setting"
+.Fa "struct crypt_data *data"
+.Fc
+.Ft "char *"
+.Fo crypt_rn
+.Fa "const char *phrase"
+.Fa "const char *setting"
+.Fa "struct crypt_data *data"
+.Fa "int size"
+.Fc
+.Ft "char *"
+.Fo crypt_ra
+.Fa "const char *phrase"
+.Fa "const char *setting"
+.Fa "void **data"
+.Fa "int *size"
+.Fc
+.Sh DESCRIPTION
 The
-.BR crypt ", " crypt_r ", " crypt_rn ", and " crypt_ra
-functions irreversibly \(lqhash\(rq
-.I phrase
+.Nm crypt ,
+.Nm crypt_r ,
+.Nm crypt_rn ,
+and
+.Nm crypt_ra
+functions irreversibly
+.Dq hash
+.Fa phrase
 for storage in the system password database
-.RB ( shadow (5))
-using a cryptographic \(lqhashing method.\(rq
-The result of this operation is called a \(lqhashed passphrase\(rq
-or just a \(lqhash.\(rq
+.Pq Xr shadow 5
+using a cryptographic
+.Dq hashing method.
+The result of this operation is called a
+.Dq hashed passphrase
+or just a
+.Dq hash.
 Hashing methods are described in
-.BR crypt (5).
-.PP
-.I setting
+.Xr crypt 5 .
+.Pp
+.Fa setting
 controls which hashing method to use,
 and also supplies various parameters to the chosen method,
-most importantly a random \(lqsalt\(rq
+most importantly a random
+.Dq salt
 which ensures that no two stored hashes are the same,
 even if the
-.I phrase
+.Fa phrase
 strings are the same.
-The hashing methods are explained below.
-.PP
+.Pp
 The
-.I crypt_data
-structure passed to
-.B crypt_r
-has at least these fields:
-.sp
-.in +4n
-.nf
+.Fa data
+argument to
+.Nm crypt_r
+is a structure of type
+.Vt "struct crypt_data" .
+It has at least these fields:
+.Bd -literal -offset indent
 struct crypt_data {
     char output[CRYPT_OUTPUT_SIZE];
     char setting[CRYPT_OUTPUT_SIZE];
     char phrase[CRYPT_MAX_PASSPHRASE_SIZE];
     char initialized;
 };
-.fi
-.in
-.PP
+.Ed
+.Pp
 Upon a successful return from
-.BR crypt_r ,
+.Nm crypt_r ,
 the hashed passphrase will be stored in
-.IR output .
+.Fa output .
 Applications are encouraged, but not required, to use the
-.I setting
+.Fa phrase
 and
-.I phrase
+.Fa setting
 fields to store the strings that they will pass as
-.I phrase
+.Fa phrase
 and
-.I setting
+.Fa setting
 to
-.BR crypt_r .
+.Nm crypt_r .
 This will make it easier to erase all sensitive data
 after it is no longer needed.
-.PP
+.Pp
 The
-.I initialized
+.Fa initialized
 field must be set to zero before the first time a
-.I crypt_data
+.Vt "struct crypt_data"
 object is first used in a call to
-.BR crypt_r .
-We recommend zeroing the entire
-.I crypt_data
-object, not just
-.I initialized
+.Fn crypt_r .
+We recommend zeroing the entire object,
+not just
+.Fa initialized
 and not just the documented fields,
 before the first use.
 (Of course, do this before storing anything in
-.I setting
+.Fa setting
 and
-.IR phrase .)
-.PP
+.Fa phrase . )
+.Pp
 The
-.I data
+.Fa data
 argument to
-.B crypt_rn
+.Nm crypt_rn
 should also point to a
-.I crypt_data
+.Vt "struct crypt_data"
 object, and
-.I size
+.Fa size
 should be the size of that object, cast to
-.BR int .
+.Vt int .
 When used with
-.BR crypt_rn ,
+.Nm crypt_rn ,
 the entire
-.I crypt_data
-object must be zeroed before its first use;
+.Fa data
+object (except for the
+.Fa phrase
+and
+.Fa setting
+fields) must be zeroed before its first use;
 this is not just a recommendation, as it is for
-.BR crypt_r .
-.RI ( setting
-and
-.I phrase
-are still allowed to be used.)
+.Nm crypt_r .
 Otherwise, the fields of the object have the same uses that they do for
-.BR crypt_r .
-.PP
+.Nm crypt_r .
+.Pp
 On the first call to
-.BR crypt_ra ,
-.I data
+.Nm crypt_ra ,
+.Fa data
 should be the address of a
-.B void *
+.Vt "void *"
 variable set to NULL, and
-.I size
+.Fa size
 should be the address of an
-.B int
+.Vt int
 variable set to zero.
-.B crypt_ra
+.Nm crypt_ra
 will allocate and initialize a
-.I crypt_data
+.Vt "struct crypt_data"
 object, using
-.BR malloc (3),
-and write its address and size into
-.RI * data
+.Xr malloc 3 ,
+and write its address and size into the variables pointed to by
+.Fa data
 and
-.RI * size .
+.Fa size .
 These can be reused in subsequent calls.
 After the application is done hashing passphrases,
-it should deallocate
-.RI * data
-using
-.BR free (3).
-.SH RETURN VALUE
+it should deallocate the
+.Vt "struct crypt_data"
+object using
+.Xr free 3 .
+.Sh RETURN VALUES
 Upon successful completion,
-.BR crypt ", " crypt_r ", " crypt_rn ", and " crypt_ra
+.Nm crypt ,
+.Nm crypt_r ,
+.Nm crypt_rn ,
+and
+.Nm crypt_ra
 return a pointer to a string which encodes both the hashed passphrase,
 and the settings that were used to encode it.
 This string is directly usable as
-.I setting
-with other calls to
-.BR crypt ", " crypt_r ", " crypt_rn ", and " crypt_ra ,
+.Fa setting
+in other calls to
+.Nm crypt ,
+.Nm crypt_r ,
+.Nm crypt_rn ,
+and
+.Nm crypt_ra ,
 and as
-.I prefix
-with calls to
-.BR crypt_gensalt ", " crypt_gensalt_rn ", and " crypt_gensalt_ra .
+.Fa prefix
+in calls to
+.Nm crypt_gensalt ,
+.Nm crypt_gensalt_rn ,
+and
+.Nm crypt_gensalt_ra .
 It will be entirely printable ASCII,
 and will not contain whitespace
-or the characters \(oq\fB:\fR\(cq,
-\(oq\fB;\fR\(cq,
-\(oq\fB*\fR\(cq,
-\(oq\fB!\fR\(cq, or
-\(oq\fB\e\fR\(cq.
+or the characters
+.Sq Li \&: ,
+.Sq Li \&; ,
+.Sq Li \&* ,
+.Sq Li \&! ,
+or
+.Sq Li \&\e .
 See
-.BR crypt (5)
+.Xr crypt 5
 for more detail on the format of hashed passphrases.
-.PP
-.B crypt
+.Pp
+.Nm crypt
 places its result in a static storage area,
 which will be overwritten by subsequent calls to
-.BR crypt .
+.Nm crypt .
 It is not safe to call
-.B crypt
+.Nm crypt
 from multiple threads simultaneously.
-.PP
-.BR crypt_r ", " crypt_rn ", and " crypt_ra
+.Pp
+.Nm crypt_r ,
+.Nm crypt_rn ,
+and
+.Nm crypt_ra
 place their result in the
-.I output
-field of the
-.I crypt_data
-object that they are supplied with; it is safe to call them from
-multiple threads simultaneously, as long as a separate
-.I crypt_data
-object is used for each thread.
-.PP
-Upon error,
-.BR crypt_r ", " crypt_rn ", and " crypt_ra
-write an
-.I invalid
-hashed passphrase to the
-.I output
+.Fa output
 field of their
-.I crypt_data
-object, and
-.B crypt
+.Fa data
+argument.
+It is safe to call them from multiple threads simultaneously,
+as long as a separate
+.Fa data
+object is used for each thread.
+.Pp
+Upon error,
+.Nm crypt_r ,
+.Nm crypt_rn ,
+and
+.Nm crypt_ra
+write an
+.Em invalid
+hashed passphrase to the
+.Fa output
+field of their
+.Fa data
+argument, and
+.Nm crypt
 writes an invalid hash to its static storage area.
 This string will be shorter than 13 characters,
-will begin with a \(oq\fB*\fR\(cq,
+will begin with a
+.Sq Li \&* ,
 and will not compare equal to
-.IR setting .
-.PP
+.Fa setting .
+.Pp
 Upon error,
-.BR crypt_rn " and " crypt_ra
+.Nm crypt_rn
+and
+.Nm crypt_ra
 return a null pointer.
-.BR crypt_r " and " crypt
+.Nm crypt_r
+and
+.Nm crypt
 may also return a null pointer,
 or they may return a pointer to the invalid hash,
-depending on how
-.I libcrypt
-was configured.
+depending on how libcrypt was configured.
 (The option to return the invalid hash is for compatibility
 with old applications that assume that
-.B crypt
+.Nm crypt
 cannot return a null pointer.
 See
-.B "PORTABILITY NOTES"
+.Sx PORTABILITY NOTES
 below.)
-.PP
+.Pp
 All four functions set
-.I errno
+.Va errno
 when they fail.
-.SH ERRORS
-.TP
-.B EINVAL
-.I setting
+.Sh ERRORS
+.Bl -tag -width Er
+.It Er EINVAL
+.Fa setting
 is invalid, or requests a hashing method that is not supported.
-.TP
-.B ERANGE
-.B crypt_rn
+.It Er ERANGE
+.Nm crypt_rn
 only:
-.I size
+.Fa size
 is too small for the hashing method requested by
-.IR setting .
-.TP
-.B ENOMEM
+.Fa setting .
+.It Er ENOMEM
 Failed to allocate internal scratch memory.
 .br
-.BR crypt_ra
+.Nm crypt_ra
 only: failed to allocate memory for
-.RI * data .
-.TP
-.BR ENOSYS " or " EOPNOTSUPP
+.Fa data .
+.It Er ENOSYS No or Er EOPNOTSUPP
 Hashing passphrases is not supported at all on this installation,
 or the hashing method requested by
-.I setting
+.Fa setting
 is not supported.
-These error codes are not used by this version of
-.IR libcrypt ,
+These error codes are not used by this version of libcrypt,
 but may be encountered on other systems.
-.SH PORTABILITY NOTES
-.PP
-.B crypt
+.El
+.Sh PORTABILITY NOTES
+.Nm crypt
 is included in POSIX, but
-.BR crypt_r ", " crypt_rn ", and " crypt_ra
+.Nm crypt_r ,
+.Nm crypt_rn ,
+and
+.Nm crypt_ra
 are not part of any standard.
-.PP
+.Pp
 POSIX does not specify any hashing methods,
 and does not require hashed passphrases to be portable between systems.
 In practice, hashed passphrases are portable
 as long as both systems support the hashing method that was used.
 However, the set of supported hashing methods
 varies considerably from system to system.
-.PP
+.Pp
 The behavior of
-.B crypt
+.Nm crypt
 on errors isn't well standardized.
 Some implementations simply can't fail
 (except by crashing the program),
 others return a null pointer or a fixed string.
 Most implementations don't set
-.IR errno ,
+.Va errno ,
 but some do.
 POSIX specifies returning a null pointer and setting
-.IR errno ,
+.Va errno ,
 but it defines only one possible error,
-.BR ENOSYS ,
+.Er ENOSYS ,
 in the case where
-.B crypt
+.Nm crypt
 is not supported at all.
-Many existing applications are not prepared to handle null pointers
+Some older applications are not prepared to handle null pointers
 returned by
-.BR crypt .
+.Nm crypt .
 The behavior described above for this implementation,
 setting
-.I errno
+.Va errno
 and returning an invalid hashed passphrase different from
-.IR setting ,
+.Fa setting ,
 is chosen to make these applications fail closed when an error occurs.
-.PP
+.Pp
 Due to historical restrictions
 on the export of cryptographic software from the USA,
-.B crypt
+.Nm crypt
 is an optional POSIX component.
 Applications should therefore be prepared for
-.B crypt
+.Nm crypt
 not to be available,
 or to always fail (setting
-.I errno
+.Va errno
 to
-.BR ENOSYS )
+.Er ENOSYS )
 at runtime.
-.PP
+.Pp
 POSIX specifies that
-.B crypt
+.Nm crypt
 is declared in
-.BR unistd.h ,
+.In unistd.h ,
 but only if the macro
-.B _XOPEN_CRYPT
-is defined and has a value greater than or equal to zero.  Since
-.I libcrypt
-does not provide
-.BR unistd.h ,
+.Dv _XOPEN_CRYPT
+is defined and has a value greater than or equal to zero.
+Since libcrypt does not provide
+.In unistd.h ,
 it declares
-.BR crypt ", " crypt_r ", " crypt_rn ", and " crypt_ra
+.Nm crypt ,
+.Nm crypt_r ,
+.Nm crypt_rn ,
+and
+.Nm crypt_ra
 in
-.B crypt.h
+.In crypt.h
 instead.
-.PP
+.Pp
 On a minority of systems (notably recent versions of Solaris),
-.B crypt
+.Nm crypt
 uses a thread-specific static storage buffer,
 which makes it safe to call from multiple threads simultaneously,
 but does not prevent each call within a thread
 from overwriting the results of the previous one.
-.SH BUGS
-.PP
+.Sh BUGS
 Some implementations of
-.BR crypt ,
+.Nm crypt ,
 upon error,
 return an invalid hash that is stored in a read-only location
 or only initialized once,
 which means that it is only safe to erase the buffer pointed to by the
-.B crypt
+.Nm crypt
 return value if an error did not occur.
-.PP
-.I struct crypt_data
-may be quite large (32kB in this implementation of
-.IR libcrypt ;
+.Pp
+.Vt "struct crypt_data"
+may be quite large (32kB in this implementation of libcrypt;
 over 128kB in some other implementations).
 This is large enough that it may be unwise to allocate it on the stack.
-.PP
+.Pp
 Some recently designed hashing methods need even more scratch memory,
 but the
-.B crypt_r
+.Nm crypt_r
 interface makes it impossible to change the size of
-.I crypt_data
+.Vt "struct crypt_data"
 without breaking binary compatibility.
 The
-.B crypt_rn
+.Nm crypt_rn
 interface could accommodate larger allocations for specific hashing methods,
 but the caller of
-.B crypt_rn
+.Nm crypt_rn
 has no way of knowing how much memory to allocate.
-.B crypt_ra
+.Nm crypt_ra
 does the allocation itself,
 but can only make a single call to
-.BR malloc (3).
-.SH ATTRIBUTES
+.Xr malloc 3 .
+.Sh ATTRIBUTES
 For an explanation of the terms used in this section, see
-.BR attributes (7).
-.ad l
+.Xr attributes 7 .
 .TS
 allbox;
 lb lb lb
 l l l.
 Interface	Attribute	Value
 T{
-.B crypt
+.Nm crypt
 T}	Thread safety	MT-Unsafe race:crypt
 T{
-.BR crypt_r ", " crypt_rn ", " crypt_ra
+.Nm crypt_r ,
+.Nm crypt_rn ,
+.Nm crypt_ra
 T}	Thread safety	MT-Safe
 .TE
-.ad b
 .sp
-.SH HISTORY
+.Sh HISTORY
 A rotor-based
-.B crypt
-function appeared in Version 6 AT&T UNIX.
-The "traditional" DES-based
-.B crypt
-first appeared in Version 7 AT&T UNIX.
-.PP
-.B crypt_r
+.Nm crypt
+function appeared in
+.At v6 .
+The
+.Dq traditional
+DES-based
+.Nm crypt
+first appeared in
+.At v7 .
+.Pp
+.Nm crypt_r
 originates with the GNU C Library.
 There's also a
-.B crypt_r
+.Nm crypt_r
 function on HP-UX and MKS Toolkit, but the prototypes and semantics
 differ.
-.PP
-.BR crypt_rn
+.Pp
+.Nm crypt_rn
 and
-.BR crypt_ra
+.Nm crypt_ra
 originate with the Openwall project.
-.SH SEE ALSO
-.ad l
-.BR crypt_gensalt (3),
-.BR getpass (3),
-.BR getpwent (3),
-.BR shadow (3),
-.BR login (1),
-.BR passwd (1),
-.BR crypt (5),
-.BR passwd (5),
-.BR shadow (5),
-.BR pam (8)
+.Sh SEE ALSO
+.Xr crypt_gensalt 3 ,
+.Xr getpass 3 ,
+.Xr getpwent 3 ,
+.Xr shadow 3 ,
+.Xr login 1 ,
+.Xr passwd 1 ,
+.Xr crypt 5 ,
+.Xr passwd 5 ,
+.Xr shadow 5 ,
+.Xr pam 8

--- a/crypt.5
+++ b/crypt.5
@@ -1,29 +1,30 @@
 .\" Written and revised by Solar Designer <solar at openwall.com> in 2000-2011.
 .\" Revised by Zack Weinberg <zackw at panix.com> in 2017.
+.\" Converted to mdoc format by Zack Weinberg in 2018.
 .\"
 .\" No copyright is claimed, and this man page is hereby placed in the public
 .\" domain.  In case this attempt to disclaim copyright and place the man page
 .\" in the public domain is deemed null and void, then the man page is
 .\" Copyright 2000-2011 Solar Designer, 2017 Zack Weinberg, and it is
- \" hereby released to the general public under the following terms:
+.\" hereby released to the general public under the following terms:
 .\"
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted.
 .\"
 .\" There's ABSOLUTELY NO WARRANTY, express or implied.
 .\"
-.\" This manual page in its current form is intended for use on systems
-.\" based on the GNU C Library with crypt_blowfish patched into libcrypt.
-.\"
-.TH CRYPT 5 "October 11, 2017" "Openwall Project" "File Formats and Conversions"
-.SH NAME
-crypt \- storage format for hashed passphrases and available hashing methods
-.SH DESCRIPTION
+.Dd October 11, 2017
+.Dt CRYPT 5
+.Os "Openwall Project"
+.Sh NAME
+.Nm crypt
+.Nd storage format for hashed passphrases and available hashing methods
+.Sh DESCRIPTION
 The hashing methods implemented by
-.BR crypt (3)
+.Xr crypt 3
 are designed only to process user passphrases for storage and authentication;
 they are not suitable for use as general-purpose cryptographic hashes.
-.PP
+.Pp
 Passphrase hashing is not a replacement for strong passphrases.
 It is always possible
 for an attacker with access to the hashed passphrases
@@ -31,196 +32,189 @@ to guess and check possible cleartext passphrases.
 However, with a strong hashing method,
 guessing will be too slow for the attacker
 to discover a strong passphrase.
-.PP
-All of the hashing methods use a \(lqsalt\(rq to perturb the hash function,
+.Pp
+All of the hashing methods use a
+.Dq salt
+to perturb the hash function,
 so that the same passphrase may produce many possible hashes.
 Newer methods accept longer salt strings.
 The salt should be chosen at random for each user.
 Salt defeats a number of attacks:
-.TP
-1.
+.Bl -enum
+.It
 It is not possible to hash a passphrase once
 and then test it against each account's stored hash;
 the hash calculation must be repeated for each account.
-.TP
-2.
+.It
 It is not possible to tell whether two accounts use the same passphrase
 without successfully guessing one of the phrases.
-.TP
-3.
+.It
 Tables of precalculated hashes of commonly used passphrases
 must have an entry for each possible salt,
 which makes them impractically large.
-.PP
+.El
+.Pp
 All of the hashing methods are also deliberately engineered to be slow;
 they use many iterations of an underlying cryptographic primitive
 to increase the cost of each guess.
 The newer hashing methods allow the number of iterations to be adjusted,
-using the \(lqCPU time cost\(rq parameter to
-.BR crypt_gensalt (3).
+using the
+.Dq CPU time cost
+parameter to
+.Xr crypt_gensalt 3 .
 This makes it possible to keep the hash slow as hardware improves.
-.SH FORMAT OF HASHED PASSPHRASES
+.Sh FORMAT OF HASHED PASSPHRASES
 All of the hashing methods supported by
-.I libcrypt
+.Xr crypt 3
 produce a hashed passphrase which consists of four components:
-.IR prefix ", " options ", " salt ", and " hash.
+.Ar prefix ,
+.Ar options ,
+.Ar salt ,
+and
+.Ar hash .
 The prefix controls which hashing method is to be used, and is the
 appropriate string to pass to
-.B crypt_gensalt
+.Xr crypt_gensalt 3
 to select that method.
 The contents of
-.IR options ", " salt ", and " hash
+.Ar options ,
+.Ar salt ,
+and
+.Ar hash
 are up to the method.
 Depending on the method, the
-.IR prefix " and " options
+.Ar prefix
+and
+.Ar options
 components may be empty.
-.PP
+.Pp
 The
-.I setting
+.Fa setting
 argument to
-.B crypt
+.Xr crypt 3
 must begin with the first three components of a valid hashed passphrase,
 but anything after that is ignored.
 This makes authentication simple:
 hash the input passphrase using the stored passphrase as the setting,
 and then compare the result to the stored passphrase.
-.PP
+.Pp
 Hashed passphrases are always entirely printable ASCII,
 and do not contain any whitespace
-or the characters \(oq\fB:\fR\(cq,
-\(oq\fB;\fR\(cq,
-\(oq\fB*\fR\(cq,
-\(oq\fB!\fR\(cq, or
-\(oq\fB\e\fR\(cq.
+or the characters
+.Sq Li \&: ,
+.Sq Li \&; ,
+.Sq Li \&* ,
+.Sq Li \&! ,
+or
+.Sq Li \&\e .
 (These characters are used as delimiters and special markers in the
-.BR passwd (5)
+.Xr passwd 5
 and
-.BR shadow (5)
+.Xr shadow 5
 files.)
-.PP
+.Pp
 The syntax of each component of a hashed passphrase
 is up to the hashing method.
-\(oq\fB$\fR\(cq characters
-usually delimit components,
+.Sq Li \&$
+characters usually delimit components,
 and the salt and hash are usually encoded as numerals in base 64.
 The details of this base-64 encoding vary among hashing methods.
-The common \(lqbase64\(rq encoding specified by RFC 4648 is usually
-.I not
+The common
+.Dq base64
+encoding specified by RFC 4648 is usually
+.Em not
 used.
-.SH AVAILABLE HASHING METHODS
+.Sh AVAILABLE HASHING METHODS
 This is a list of
-.I all
+.Em all
 the hashing methods supported by
-.IR libcrypt ,
+.Xr crypt 3 ,
 in decreasing order of strength.
 Many of the older methods
 are now considered too weak to use for new passphrases.
 The hashed passphrase format is expressed
 with extended regular expressions (see
-.BR regex (7))
+.Xr regex 7 )
 and does not show the division into prefix, options, salt, and hash.
 .de hash
-.ad l
-.TP
-.B prefix
+.Bl -tag -width 2n
+.It Sy Prefix
+.\" mandoc bug: .Qq comes out with curly quptes.
+.\" mandoc bug: .Li is hyperlinked to itself for no apparent reason.
+.Bf Li
 "\\$1"
+.Ef
 .if "\\$1"" (empty string)
-.TP
-.B Hashed passphrase format
-\\$2
-.TP
-.B Maximum passphrase length
+.It Sy Hashed passphrase format
+.\" mandoc bug: .Li is hyperlinked to itself for no apparent reason.
+.Bf -literal
+\&\\$2
+.Ef
+.It Sy Maximum passphrase length
 .ie "\\$3"unlimited" unlimited
 .el \\$3 characters
 .if "\\$4"7" (ignores 8th bit)
-.TP
-.B Hash size
+.It Sy Hash size
 \\$6 bits
-.if !"\\$5"\\$6" \{
-.TP
-.B Effective key size
-\\$5 bits
+.if !"\\$5"\\$6" \{\
+.It Sy Effective key size
+\&\\$5 bits
 .\}
-.TP
-.B Salt size
+.It Sy Salt size
 \\$7 bits
-.TP
-.B CPU time cost parameter
+.It Sy CPU time cost parameter
 \\$8
-.ad b
+.El
 ..
-.PP
-.ti -4
-.B yescrypt
-.br
-yescrypt is a scalable passphrase hashing scheme designed by Solar
-Designer, which is based on Colin Percival's scrypt.
+.Ss yescrypt
+yescrypt is a scalable passphrase hashing scheme designed by Solar Designer,
+which is based on Colin Percival's scrypt.
 Recommended for new hashes.
 .hash "$y$" "\e$y\e$[./A-Za-z0-9]+\e$[./A-Za-z0-9]{,86}\e$[./A-Za-z0-9]{43}" unlimited 8 256 256 "up to 512" "1 to 11 (logarithmic)"
-.PP
-.ti -4
-.B scrypt
-.br
+.Ss scrypt
 scrypt is a password-based key derivation function created by Colin Percival,
 originally for the Tarsnap online backup service.
 The algorithm was specifically designed to make it costly to perform
 large-scale custom hardware attacks by requiring large amounts of memory.
 In 2016, the scrypt algorithm was published by IETF as RFC 7914.
 .hash "$7$" "\e$7\e$[./A-Za-z0-9]{11,97}\e$[./A-Za-z0-9]{43}" unlimited 8 256 256 "up to 512" "6 to 11 (logarithmic)"
-.PP
-.ti -4
-.B bcrypt
-.br
+.Ss bcrypt
 A hash based on the Blowfish block cipher,
 modified to have an extra-expensive key schedule.
 Originally developed by Niels Provos and David Mazieres for OpenBSD
 and also supported on recent versions of FreeBSD and NetBSD,
 on Solaris 10 and newer, and on several GNU/*/Linux distributions.
 .hash "$2b$" "\e$2[abxy]\e$[0-9]{2}\e$[./A-Za-z0-9]{53}" 72 8 184 184 128 "4 to 31 (logarithmic)"
-.PP
+.Pp
 The alternative prefix "$2y$" is equivalent to "$2b$".
 It exists for historical reasons only.
 The alternative prefixes "$2a$" and "$2x$"
 provide bug-compatibility with crypt_blowfish 1.0.4 and earlier,
 which incorrectly processed characters with the 8th bit set.
-.PP
-.ti -4
-.B SHA-2-512
-.br
+.Ss SHA-2-512
 A hash based on SHA-2 with 512-bit output,
 originally developed by Ulrich Drepper for GNU libc.
 Supported on Linux but not common elsewhere.
 Acceptable for new hashes.
 The default CPU time cost parameter is 5000,
 which is too low for modern hardware.
-.br
 .hash "$6$" "\e$6\e$(rounds=[1-9][0-9]+\e$)?[./0-9A-Za-z]{1,16}\e$[./0-9A-Za-z]{86}" unlimited 8 512 512 "6 to 96" "1000 to 999,999,999"
-.PP
-.ti -4
-.B SHA-2-256
-.br
+.Ss SHA-2-256
 A hash based on SHA-2 with 256-bit output,
 originally developed by Ulrich Drepper for GNU libc.
 Supported on Linux but not common elsewhere.
 Acceptable for new hashes.
 The default CPU time cost parameter is 5000,
 which is too low for modern hardware.
-.br
 .hash "$5$" "\e$5\e$(rounds=[1-9][0-9]+\e$)?[./0-9A-Za-z]{1,16}\e$[./0-9A-Za-z]{43}" unlimited 8 256 256 "6 to 96" "1000 to 999,999,999"
-.PP
-.ti -4
-.B SHA-1
-.br
+.Ss SHA-1
 A hash based on HMAC-SHA1.
 Originally developed by Simon Gerraty for NetBSD.
 Not as weak as the DES-based hashes below,
 but SHA1 is so cheap on modern hardware
 that it should not be used for new hashes.
 .hash "$sha1" "\e$sha1\e$[1-9][0-9]+\e$[./0-9A-Za-z]{1,64}\e$[./0-9A-Za-z]{8,64}[./0-9A-Za-z]{32}" unlimited 8 160 160 "6 to 384" "4 to 4,294,967,295"
-.PP
-.ti -4
-.B MD5 (Sun)
-.br
+.Ss MD5 (Sun)
 A hash based on the MD5 algorithm,
 with additional cleverness to make precomputation difficult,
 originally developed by Alec David Muffet for Solaris.
@@ -229,10 +223,7 @@ Not as weak as the DES-based hashes below,
 but MD5 is so cheap on modern hardware
 that it should not be used for new hashes.
 .hash "$md5" "\e$md5(,rounds=[1-9][0-9]+)?\e$[./0-9A-Za-z]{8}\e${1,2}[./0-9A-Za-z]{22}" unlimited 8 128 128 48 "4096 to 4,294,963,199"
-.PP
-.ti -4
-.B MD5 (FreeBSD)
-.br
+.Ss MD5 (FreeBSD)
 A hash based on the MD5 algorithm, originally developed by
 Poul-Henning Kamp for FreeBSD.
 Supported on most free Unixes and newer versions of Solaris.
@@ -241,10 +232,7 @@ but MD5 is so cheap on modern hardware
 that it should not be used for new hashes.
 CPU time cost is not adjustable.
 .hash "$1$" "\e$1\e$[^$]{1,8}\e$[./0-9A-Za-z]{22}" unlimited 8 128 128 "6 to 48" 1000
-.PP
-.ti -4
-.B BSDI extended DES
-.br
+.Ss BSDI extended DES
 A weak extension of traditional DES,
 which eliminates the length limit,
 increases the salt size,
@@ -255,10 +243,7 @@ due to the use of David Burren's FreeSec library.
 It is better than bigcrypt and traditional DES,
 but still should not be used for new hashes.
 .hash _ "_[./0-9A-Za-z]{19}" unlimited 7 56 64 24 "1 to 16,777,215 (must be odd)"
-.PP
-.ti -4
-.B bigcrypt
-.br
+.Ss bigcrypt
 A weak extension of traditional DES,
 available on some System V-derived Unixes.
 All it does is raise the length limit from 8 to 128 characters,
@@ -266,49 +251,51 @@ and it does this in a crude way that allows attackers to
 guess chunks of a long passphrase in parallel.
 It should not be used for new hashes.
 .hash "" "[./0-9A-Za-z]{13,178}" 128 7 "up to 896" "up to 1024" 12 25
-.PP
-.ti -4
-.B Traditional DES-based
-.br
+.Ss Traditional DES
 The original hashing method from Unix V7, based on the DES block cipher.
 Because DES is cheap on modern hardware,
 because there are only 4096 possible salts and 2**56 possible hashes,
 and because it truncates passphrases to 8 characters,
 it is feasible to discover
-.I any
+.Em any
 passphrase hashed with this method.
 It should only be used if you absolutely have to generate hashes
 that will work on an old operating system that supports nothing else.
 .hash "" "[./0-9A-Za-z]{13}" 8 7 56 64 12 25
-.PP
-.ti -4
-.B NTHASH
-.br
+.Ss NTHASH
 The hashing method used for network authentication
 in some versions of the SMB/CIFS protocol.
 Available, for cross-compatibility's sake, on FreeBSD.
 Based on MD4.
 Has no salt or tunable cost parameter.
 Like traditional DES, it is so weak that
-.I any
+.Em any
 passphrase hashed with this method is guessable.
 It should only be used if you absolutely have to generate hashes
 that will work on an old operating system that supports nothing else.
 .hash "$3$" "\e$3\e$\e$[0-9a-f]{32}" unlimited 8 256 256 0 1
-.SH SEE ALSO
-.BR crypt (3),
-.BR crypt_gensalt (3),
-.BR getpwent (3),
-.BR passwd (5),
-.BR shadow (5),
-.BR pam (8)
-.sp
-Niels Provos and David Mazieres.  A Future-Adaptable Password Scheme.
-Proceedings of the 1999 USENIX Annual Technical Conference, June 1999.
-.br
-https://www.usenix.org/events/usenix99/provos.html
-.sp
-Robert Morris and Ken Thompson.  Password Security: A Case History.
-Communications of the ACM, Volume 22, Issue 11, 1979.
-.br
-http://wolfram.schneider.org/bsd/7thEdManVol2/password/password.pdf
+.Sh SEE ALSO
+.Xr crypt 3 ,
+.Xr crypt_gensalt 3 ,
+.Xr getpwent 3 ,
+.Xr passwd 5 ,
+.Xr shadow 5 ,
+.Xr pam 8
+.Rs
+.%A Niels Provos
+.%A David Mazieres
+.%T A Future-Adaptable Password Scheme
+.%B Proceedings of the 1999 USENIX Annual Technical Conference
+.%D June 1999
+.%U https://www.usenix.org/events/usenix99/provos.html
+.Re
+.Rs
+.%A Robert Morris
+.%A Ken Thompson
+.%T Password Security: A Case History
+.%J Communications of the ACM
+.%V 22
+.%N 11
+.%D 1979
+.%U http://wolfram.schneider.org/bsd/7thEdManVol2/password/password.pdf
+.Re

--- a/crypt_gensalt.3
+++ b/crypt_gensalt.3
@@ -1,5 +1,6 @@
 .\" Written and revised by Solar Designer <solar at openwall.com> in 2000-2011.
 .\" Revised by Zack Weinberg <zackw at panix.com> in 2017.
+.\" Converted to mdoc format by Zack Weinberg in 2018.
 .\"
 .\" No copyright is claimed, and this man page is hereby placed in the public
 .\" domain.  In case this attempt to disclaim copyright and place the man page
@@ -12,230 +13,255 @@
 .\"
 .\" There's ABSOLUTELY NO WARRANTY, express or implied.
 .\"
-.\" This manual page in its current form is intended for use on systems
-.\" based on the GNU C Library with crypt_blowfish patched into libcrypt.
-.\"
-.TH CRYPT_GENSALT 3 "October 9, 2017" "Openwall Project" "Library Functions"
-.ad l
-.\" No macros in NAME to keep makewhatis happy.
-.SH NAME
-\fBcrypt_gensalt\fR, \fBcrypt_gensalt_rn\fR, \fBcrypt_gensalt_ra\fR
-\- encode settings for passphrase hashing
-.SH SYNOPSIS
-.B #include <crypt.h>
-.sp
-.in +8
-.ti -8
-.BI "char *crypt_gensalt(const char *" prefix ", unsigned long " count ", const char *" rbytes ", int " nrbytes );
-.ti -8
-.BI "char *crypt_gensalt_rn(const char *" prefix ", unsigned long " count ", const char *" rbytes ", int " nrbytes ", char *" output ", int " output_size );
-.ti -8
-.BI "char *crypt_gensalt_ra(const char *" prefix ", unsigned long " count ", const char *" rbytes ", int " nrbytes );
-.in -8
-.sp
-Link with
-.IR -lcrypt .
-.ad b
-.SH DESCRIPTION
-.BR crypt_gensalt ", " crypt_gensalt_rn ", and " crypt_gensalt_ra
-compile a string for use as the
-.I setting
+.Dd October 11, 2017
+.Dt CRYPT_GENSALT 3
+.Os "Openwall Project"
+.Sh NAME
+.Nm crypt_gensalt , crypt_gensalt_rn , crypt_gensalt_ra
+.Nd encode settings for passphrase hashing
+.Sh LIBRARY
+.Lb libcrypt
+.Sh SYNOPSIS
+.In crypt.h
+.Ft "char *"
+.Fo crypt_gensalt
+.Fa "const char *prefix"
+.Fa "unsigned long count"
+.Fa "const char *rbytes"
+.Fa "int nrbytes"
+.Fc
+.Ft "char *"
+.Fo crypt_gensalt_rn
+.Fa "const char * prefix"
+.Fa "unsigned long count"
+.Fa "const char *rbytes"
+.Fa "int nrbytes"
+.Fa "char * output"
+.Fa "int output_size"
+.Fc
+.Ft "char *"
+.Fo crypt_gensalt_ra
+.Fa "const char *prefix"
+.Fa "unsigned long count"
+.Fa "const char *rbytes"
+.Fa "int nrbytes"
+.Fc
+.Sh DESCRIPTION
+The
+.Nm crypt_gensalt ,
+.Nm crypt_gensalt_rn ,
+and
+.Nm crypt_gensalt_ra
+functions compile a string for use as the
+.Fa setting
 argument to
-.BR crypt ", " crypt_r ", " crypt_rn ", and " crypt_ra .
-.PP
-.I prefix
-selects the hashing method to use;
-.I count
+.Nm crypt ,
+.Nm crypt_r ,
+.Nm crypt_rn ,
+and
+.Nm crypt_ra .
+.Fa prefix
+selects the hashing method to use.
+.Fa count
 controls the CPU time cost of the hash;
 the valid range for
-.I count
-and the exact meaning of \(lqCPU time cost\(rq
+.Fa count
+and the exact meaning of
+.Dq CPU time cost
 depends on the hashing method,
 but larger numbers correspond to more costly hashes.
-.I rbytes
+.Fa rbytes
 should point to
-.I nrbytes
-cryptographically random bytes for use as \(lqsalt.\(rq
-.PP
+.Fa nrbytes
+cryptographically random bytes for use as
+.Dq salt.
+.Pp
 If
-.I prefix
+.Fa prefix
 is a null pointer, the best available hashing method will be selected.
-(CAUTION: if
-.I prefix
+.Po Sy CAUTION :
+if
+.Fa prefix
 is an empty string,
-the \(lqtraditional\(rq DES-based hashing method will be selected;
-this method is unacceptably weak by modern standards.)
+the
+.Dq traditional
+DES-based hashing method will be selected;
+this method is unacceptably weak by modern standards.
+.Pc
 If
-.I count
+.Fa count
 is 0, a low default cost will be selected.
 If
-.I rbytes
+.Fa rbytes
 is a null pointer, an appropriate number of random bytes will be
 obtained from the operating system, and
-.I nrbytes
+.Fa nrbytes
 is ignored.
-.PP
+.Pp
 See
-.BR crypt (5)
+.Xr crypt 5
 for other strings that can be used as
-.IR prefix ,
+.Fa prefix ,
 and valid values of
-.IR count
+.Fa count
 for each.
-.SH RETURN VALUE
-.BR crypt_gensalt ", " crypt_gensalt_rn ", and " crypt_gensalt_ra
+.Sh RETURN VALUES
+.Nm crypt_gensalt ,
+.Nm crypt_gensalt_rn ,
+and
+.Nm crypt_gensalt_ra
 return a pointer to an encoded setting string.
 This string will be entirely printable ASCII,
-and will not contain whitespace
-or the characters \(oq\fB:\fR\(cq,
-\(oq\fB;\fR\(cq,
-\(oq\fB*\fR\(cq,
-\(oq\fB!\fR\(cq, or
-\(oq\fB\e\fR\(cq.
+and will not contain whitespace or the characters
+.Sq Li \&: ,
+.Sq Li \&; ,
+.Sq Li \&* ,
+.Sq Li \&! ,
+or
+.Sq Li \&\e .
 See
-.BR crypt (5)
+.Xr crypt 5
 for more detail on the format of this string.
 Upon error, they return a null pointer and set
-.I errno
+.Va errno
 to an appropriate error code.
-.PP
-.B crypt_gensalt
+.Pp
+.Nm crypt_gensalt
 places its result in a static storage area,
 which will be overwritten by subsequent calls to
-.BR crypt_gensalt .
+.Nm crypt_gensalt .
 It is not safe to call
-.B crypt_gensalt
+.Nm crypt_gensalt
 from multiple threads simultaneously.
 However, it
-.I is
+.Em is
 safe to pass the string returned by
-.B crypt_gensalt
+.Nm crypt_gensalt
 directly to
-.B crypt
+.Nm crypt
 without copying it;
 each function has its own static storage area.
-.PP
-.B crypt_gensalt_rn
+.Pp
+.Nm crypt_gensalt_rn
 places its result in the supplied
-.I output
+.Fa output
 buffer, which has
-.I output_size
+.Fa output_size
 bytes of storage available.
-.I output_size
+.Fa output_size
 should be greater than or equal to
-.BR CRYPT_GENSALT_OUTPUT_SIZE .
-.PP
-.B crypt_gensalt_ra
+.Dv CRYPT_GENSALT_OUTPUT_SIZE .
+.Pp
+.Nm crypt_gensalt_ra
 allocates memory for its result using
-.BR malloc (3).
+.Xr malloc 3 .
 It should be freed with
-.BR free (3)
+.Xr free 3
 after use.
-.PP
+.Pp
 Upon error, in addition to returning a null pointer,
-.BR crypt_gensalt " and " crypt_gensalt_rn
+.Nm crypt_gensalt
+and
+.Nm crypt_gensalt_rn
 will write an invalid setting string
 to their output buffer, if there is enough space;
-this string will begin with a \(oq\fB*\fR\(cq
+this string will begin with a
+.Sq Li \&*
 and will not be equal to
-.IR prefix .
-.SH ERRORS
-.ad l
-.nh
-.TP
-.B EINVAL
-.I prefix
+.Fa prefix .
+.Sh ERRORS
+.Bl -tag -width Er
+.It Er EINVAL
+.Fa prefix
 is invalid or not supported by this implementation;
-.I count
+.Fa count
 is invalid for the requested
-.IR prefix ;
+.Fa prefix ;
 the input
-.I nrbytes
+.Fa nrbytes
 is insufficient for the smallest valid salt with the requested
-.IR prefix .
-.TP
-.B ERANGE
-.BR crypt_gensalt_rn
+.Fa prefix .
+.It Er ERANGE
+.Nm crypt_gensalt_rn
 only:
-.I output_size
+.Fa output_size
 is too small to hold the compiled
-.I setting
+.Fa setting
 string.
-.TP
-.B ENOMEM
+.It Er ENOMEM
 Failed to allocate internal scratch memory.
 .br
-.BR crypt_gensalt_ra
+.Nm crypt_gensalt_ra
 only:
 failed to allocate memory for the compiled
-.I setting
+.Fa setting
 string.
-.TP
-.BR ENOSYS ", " EACCES ", " EIO ", etc.\&"
+.It Er ENOSYS , EACCES , EIO , No etc.\&
 Obtaining random bytes from the operating system failed.
-.br
 This can only happen when
-.I rbytes
+.Fa rbytes
 is a null pointer.
-.ad b
-.hy 1
-.SH FEATURE TEST MACROS
+.El
+.Sh FEATURE TEST MACROS
 The following macros are defined by
-.BR crypt.h :
-.TP
-.B CRYPT_GENSALT_IMPLEMENTS_DEFAULT_PREFIX
-A null pointer can be specified as
-.I prefix
+.In crypt.h :
+.Bl -tag -width 6n
+.It Dv CRYPT_GENSALT_IMPLEMENTS_DEFAULT_PREFIX
+A null pointer can be specified as the
+.Fa prefix
 argument.
-.TP
-.B CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY
-A null pointer can be specified as
-.I rbytes
+.It Dv CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY
+A null pointer can be specified as the
+.Fa rbytes
 argument.
-.SH PORTABILITY NOTES
+.El
+.Sh PORTABILITY NOTES
 The functions
-.BR crypt_gensalt ", " crypt_gensalt_rn ", and " crypt_gensalt_ra
+.Nm crypt_gensalt ,
+.Nm crypt_gensalt_rn ,
+and
+.Nm crypt_gensalt_ra
 are not part of any standard.
 They originate with the Openwall project.
 A function with the name
-.B crypt_gensalt
+.Nm crypt_gensalt
 also exists on Solaris 10 and newer, but its prototype and semantics differ.
-.PP
+.Pp
 The default prefix and auto entropy features are available since libxcrypt
 version 4.0.0.  Portable software can use feature test macros to find out
-whether null pointers could be specified as
-.I prefix
+whether null pointers can be used for the
+.Fa prefix
 and
-.I rbytes
+.Fa rbytes
 arguments.
-.PP
+.Pp
 The set of supported hashing methods varies considerably from system
 to system.
-.SH ATTRIBUTES
+.Sh ATTRIBUTES
 For an explanation of the terms used in this section, see
-.BR attributes (7).
+.Xr attributes 7 .
 .TS
 allbox;
 lb lb lb
 l l l.
 Interface	Attribute	Value
 T{
-.B crypt_gensalt
+.Nm crypt_gensalt
 T}	Thread safety	MT-Unsafe race:crypt_gensalt
 T{
-.BR crypt_gensalt_rn ", " crypt_gensalt_ra
+.Nm crypt_gensalt_rn ,
+.Nm crypt_gensalt_ra
 T}	Thread safety	MT-Safe
 .TE
 .sp
-.SH SEE ALSO
-.ad l
-.BR crypt (3),
-.BR getpass (3),
-.BR getpwent (3),
-.BR shadow (3),
-.BR login (1),
-.BR passwd (1),
-.BR crypt (5),
-.BR passwd (5),
-.BR shadow (5),
-.BR pam (8)
+.Sh SEE ALSO
+.Xr crypt 3 ,
+.Xr getpass 3 ,
+.Xr getpwent 3 ,
+.Xr shadow 3 ,
+.Xr login 1 ,
+.Xr passwd 1 ,
+.Xr crypt 5 ,
+.Xr passwd 5 ,
+.Xr shadow 5 ,
+.Xr pam 8


### PR DESCRIPTION
I've been looking into the possibility of generating HTML documentation from our manpages, to be hosted on Github Pages or something similar.  I'm not sure when I will get around to finishing that project, but as a first step I would like to propose we convert the manpages from traditional tmac.an format to the newer tmac.doc format, and I'd like to merge that now, so that I don't have a long-lived branch whose first changeset involves a big messy reformatting operation that's very likely to conflict with future changes to these files.

mdoc is much more semantic than man, and is therefore a better starting point for generation of HTML pages.  Also, the “mandoc” program for generating HTML from mdoc source is actually maintained, unlike “man2html.”  GNU troff has shipped tmac.doc for many years, so I don't think this should pose a compatibility problem with any system where libxcrypt is likely to be used.

This conversion deliberately ignores some of the documented mdoc conventions: in particular, I think SEE ALSO belongs at the end, and it’s better to put the pages in the same section as the current page first in the SEE ALSO list.

This conversion also winds up rendering slightly better with GNU “nroff -mdoc” than with mandoc, because mandoc doesn’t implement macros inside tbl cells; this is a known missing feature that’s already on their to-do list.