### PR TITLE
Use macros to detect endianness if configure cannot tell.

### DIFF
--- a/alg-sha1.c
+++ b/alg-sha1.c
@@ -81,7 +81,7 @@ modified for use with libxcrypt
 /* blk0() and blk() perform the initial expand. */
 /* I got the idea of expanding during the round function from SSLeay */
 /* FIXME: can we do this in an endian-proof way? */
-#if IS_BIGENDIAN
+#if XCRYPT_USE_BIGENDIAN
 #define blk0(i) block.l[i]
 #else
 #define blk0(i) (block.l[i] = (rol(block.l[i],24)&0xFF00FF00) \

--- a/alg-sha512.c
+++ b/alg-sha512.c
@@ -32,7 +32,7 @@
 #include "alg-sha512.h"
 #include "alg-yescrypt-sysendian.h"
 
-#if IS_BIGENDIAN
+#if XCRYPT_USE_BIGENDIAN
 /* Copy a vector of big-endian uint64_t into a vector of bytes */
 #define be64enc_vect(dst, src, len)	\
 	memcpy((void *)dst, (const void *)src, (size_t)len)
@@ -41,7 +41,7 @@
 #define be64dec_vect(dst, src, len)	\
 	memcpy((void *)dst, (const void *)src, (size_t)len)
 
-#else /* IS_BIGENDIAN */
+#else /* XCRYPT_USE_BIGENDIAN */
 
 /*
  * Encode a length len/4 vector of (uint64_t) into a length len vector of
@@ -69,7 +69,7 @@ be64dec_vect(uint64_t *dst, const unsigned char *src, size_t len)
 		dst[i] = be64dec(src + i * 8);
 }
 
-#endif /* IS_BIGENDIAN */
+#endif /* XCRYPT_USE_BIGENDIAN */
 
 /* SHA512 round constants. */
 static const uint64_t K[80] = {

--- a/configure.ac
+++ b/configure.ac
@@ -47,11 +47,12 @@ LT_INIT
 
 # Check for system's endianness
 AC_C_BIGENDIAN(
-   AC_DEFINE([IS_BIGENDIAN], 1,
-    [Define to 1 if system's architecture is big-endian.]),
-   AC_DEFINE([IS_BIGENDIAN], 0,
-    [Define to 0 if system's architecture is little-endian.])
+  AC_DEFINE(XCRYPT_BE_ARCH, 1, [System is bigendian.]),
+  AC_DEFINE(XCRYPT_LE_ARCH, 1, [System is littleendian.]),
+  AC_MSG_WARN([Relying on macros defined in "crypt-port.h" to detect system's endianness.]),
+  AC_MSG_WARN([Relying on macros defined in "crypt-port.h" to detect system's endianness.])
 )
+
 # One of the test scripts needs to use -dD.
 AC_CACHE_CHECK([whether the preprocessor ($CPP) supports -dD],
   [ac_cv_prog_cc_dD],

--- a/crypt-bcrypt.c
+++ b/crypt-bcrypt.c
@@ -63,7 +63,7 @@ typedef uint32_t BF_word;
 typedef int32_t BF_word_signed;
 
 /* Set the int_to_cpu function according to the system's endianness */
-#if IS_BIGENDIAN
+#if XCRYPT_USE_BIGENDIAN
 #define BF_WORD_TO_CPU(x)               be32_to_cpu (x)
 #else
 #define BF_WORD_TO_CPU(x)               le32_to_cpu (x)
@@ -458,7 +458,7 @@ BF_encode (unsigned char *dst, const BF_word * src, int size)
   while (sptr < end);
 }
 
-#if IS_BIGENDIAN
+#if XCRYPT_USE_BIGENDIAN
 static void
 BF_swap (ARG_UNUSED(BF_word * x), ARG_UNUSED(int count))
 {

--- a/crypt-port.h
+++ b/crypt-port.h
@@ -62,6 +62,83 @@
 #define MIN_SIZE(x) (x)
 #endif
 
+/* Macros for detecting endianness of the system at compile time.  */
+#if !(defined XCRYPT_BE_ARCH || defined XCRYPT_LE_ARCH) && \
+     (defined __ARMEB__ || defined __THUMBEB__ || defined __AARCH64EB__ || \
+      defined _MIPSEB || defined __MIPSEB || defined __MIPSEB__ || \
+     (defined __BYTE_ORDER__ && defined __ORDER_BIG_ENDIAN__ && \
+         __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) || \
+     (defined __BYTE_ORDER__ && defined __BIG_ENDIAN__ && \
+         __BYTE_ORDER__ == __BIG_ENDIAN__) || \
+     (defined __BYTE_ORDER && defined __ORDER_BIG_ENDIAN && \
+         __BYTE_ORDER == __ORDER_BIG_ENDIAN) || \
+     (defined __BYTE_ORDER && defined __BIG_ENDIAN && \
+         __BYTE_ORDER == __BIG_ENDIAN) || \
+     (defined BYTE_ORDER && defined ORDER_BIG_ENDIAN && \
+         BYTE_ORDER == ORDER_BIG_ENDIAN) || \
+     (defined BYTE_ORDER && defined BIG_ENDIAN && \
+         BYTE_ORDER == BIG_ENDIAN) || \
+     (defined __FLOAT_WORD_ORDER__ && defined __ORDER_BIG_ENDIAN__ && \
+         __FLOAT_WORD_ORDER__ == __ORDER_BIG_ENDIAN__) || \
+     (defined __FLOAT_WORD_ORDER__ && defined __BIG_ENDIAN__ && \
+         __FLOAT_WORD_ORDER__ == __BIG_ENDIAN__) || \
+     (defined __FLOAT_WORD_ORDER && defined __ORDER_BIG_ENDIAN && \
+         __FLOAT_WORD_ORDER == __ORDER_BIG_ENDIAN) || \
+     (defined __FLOAT_WORD_ORDER && defined __BIG_ENDIAN && \
+         __FLOAT_WORD_ORDER == __BIG_ENDIAN) || \
+     (defined FLOAT_WORD_ORDER && defined ORDER_BIG_ENDIAN && \
+         FLOAT_WORD_ORDER == ORDER_BIG_ENDIAN) || \
+     (defined FLOAT_WORD_ORDER && defined BIG_ENDIAN && \
+         FLOAT_WORD_ORDER == BIG_ENDIAN) || \
+      defined __BIG_ENDIAN__)
+#define XCRYPT_BE_ARCH 1
+#endif
+
+#if !(defined XCRYPT_BE_ARCH || defined XCRYPT_LE_ARCH) && \
+     (defined __ARMEL__ || defined __THUMBEL__ || defined __AARCH64EL__ || \
+      defined _MIPSEL || defined __MIPSEL || defined __MIPSEL__ || \
+     (defined __BYTE_ORDER__ && defined __ORDER_LITTLE_ENDIAN__ && \
+         __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) || \
+     (defined __BYTE_ORDER__ && defined __LITTLE_ENDIAN__ && \
+         __BYTE_ORDER__ == __LITTLE_ENDIAN__) || \
+     (defined __BYTE_ORDER && defined __ORDER_LITTLE_ENDIAN && \
+         __BYTE_ORDER == __ORDER_LITTLE_ENDIAN) || \
+     (defined __BYTE_ORDER && defined __LITTLE_ENDIAN && \
+         __BYTE_ORDER == __LITTLE_ENDIAN) || \
+     (defined BYTE_ORDER && defined ORDER_LITTLE_ENDIAN && \
+         BYTE_ORDER == ORDER_LITTLE_ENDIAN) || \
+     (defined BYTE_ORDER && defined LITTLE_ENDIAN && \
+         BYTE_ORDER == LITTLE_ENDIAN) || \
+     (defined __FLOAT_WORD_ORDER__ && defined __ORDER_LITTLE_ENDIAN__ && \
+         __FLOAT_WORD_ORDER__ == __ORDER_LITTLE_ENDIAN__) || \
+     (defined __FLOAT_WORD_ORDER__ && defined __LITTLE_ENDIAN__ && \
+         __FLOAT_WORD_ORDER__ == __LITTLE_ENDIAN__) || \
+     (defined __FLOAT_WORD_ORDER && defined __ORDER_LITTLE_ENDIAN && \
+         __FLOAT_WORD_ORDER == __ORDER_LITTLE_ENDIAN) || \
+     (defined __FLOAT_WORD_ORDER && defined __LITTLE_ENDIAN && \
+         __FLOAT_WORD_ORDER == __LITTLE_ENDIAN) || \
+     (defined FLOAT_WORD_ORDER && defined ORDER_LITTLE_ENDIAN && \
+         FLOAT_WORD_ORDER == ORDER_LITTLE_ENDIAN) || \
+     (defined FLOAT_WORD_ORDER && defined LITTLE_ENDIAN && \
+         FLOAT_WORD_ORDER == LITTLE_ENDIAN) || \
+      defined __LITTLE_ENDIAN__)
+#define XCRYPT_LE_ARCH 1
+#endif
+
+#if defined(XCRYPT_BE_ARCH) && !defined(XCRYPT_LE_ARCH) && !defined(XCRYPT_USE_BIGENDIAN)
+# define XCRYPT_USE_BIGENDIAN 1
+#endif
+#if defined(XCRYPT_LE_ARCH) && !defined(XCRYPT_BE_ARCH) && !defined(XCRYPT_USE_BIGENDIAN)
+# define XCRYPT_USE_BIGENDIAN 0
+#endif
+
+#if defined(XCRYPT_BE_ARCH) && defined(XCRYPT_LE_ARCH)
+# error "Cannot compile libxcrypt on a system which has different endians the same time!"
+#endif
+#if !defined(XCRYPT_USE_BIGENDIAN)
+# error "Cannot compile libxcrypt on a system with unknown endianness!"
+#endif
+
 /* static_assert shim.  */
 #ifdef HAVE_STATIC_ASSERT_IN_ASSERT_H
 /* nothing to do */
@@ -229,7 +306,7 @@ _xcrypt_strcpy_or_abort (void *dst, const size_t d_size,
 #if defined __MMX__ && __MMX__ >= 1
 #define __GOST3411_HAS_MMX__ 1
 #endif
-#if IS_BIGENDIAN
+#if XCRYPT_USE_BIGENDIAN
 #define __GOST3411_BIG_ENDIAN__ 1
 #else
 #define __GOST3411_LITTLE_ENDIAN__ 1


### PR DESCRIPTION
Some systems provide a way to build a single binary that runs on any of their architectures.  Thus detecting the system's endianness statically during configure stage is not sufficient.

Fixes #42.