### PR TITLE
Darwin doesn't support strong aliases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@
 /test-badsetting
 /test-bigcrypt
 /test-byteorder
+/test-compile-strong-alias
 /test-crypt-badargs
 /test-crypt-bcrypt
 /test-crypt-des

--- a/LICENSING
+++ b/LICENSING
@@ -53,7 +53,7 @@ source tree.  For specific licensing terms consult the files themselves.
    crypt-scrypt.c
 
  * Copyright Björn Esser; 0-clause BSD:
-   test-short-outbuf.c
+   test-compile-strong-alias.c test-short-outbuf.c
 
  * Copyright Michael Bretterklieber, Björn Esser et al.; 2-clause BSD:
    crypt-nthash.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -176,7 +176,7 @@ check_PROGRAMS = \
 	test-crypt-pbkdf1-sha1 test-crypt-scrypt test-crypt-sha256 \
 	test-crypt-sha512 test-crypt-sunmd5 test-crypt-yescrypt \
 	test-byteorder test-badsalt test-badsetting test-gensalt \
-	test-crypt-badargs test-short-outbuf \
+	test-crypt-badargs test-short-outbuf test-compile-strong-alias \
         test-getrandom-interface test-getrandom-fallbacks
 
 if ENABLE_OBSOLETE_API

--- a/crypt-port.h
+++ b/crypt-port.h
@@ -228,8 +228,17 @@ _xcrypt_strcpy_or_abort (void *dst, const size_t d_size,
 
 /* Define ALIASNAME as a strong alias for NAME.  */
 #define strong_alias(name, aliasname) _strong_alias(name, aliasname)
-#define _strong_alias(name, aliasname) \
+
+/* Darwin doesn't support alias attributes.  */
+#ifndef __APPLE__
+# define _strong_alias(name, aliasname) \
   extern __typeof (name) aliasname __attribute__ ((alias (#name)))
+#else
+# define _strong_alias(name, aliasname) \
+  __asm__(".globl _" #aliasname); \
+  __asm__(".set _" #aliasname ", _" #name); \
+  extern __typeof(name) aliasname
+#endif
 
 /* Set the symbol version for EXTNAME, which uses INTNAME as its
    implementation.  */

--- a/test-compile-strong-alias.c
+++ b/test-compile-strong-alias.c
@@ -1,0 +1,43 @@
+/* Copyright (C) 2018 Björn Esser <besser82@fedoraproject.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/* Simple compile test for our macro definition of strong_alias().
+   The sole purpose of this test is the fact some platforms do not
+   support strong aliases, some don't support aliases at all.
+   We test it just in case we may need this macro on those platforms
+   some time in the future.  */
+
+#include "crypt-port.h"
+
+/* Prototype  */
+int addition (int, int);
+
+int addition (int a, int b)
+{
+  return a + b;
+}
+strong_alias (addition, add);
+
+int
+main (void)
+{
+  int a =  1;
+  int b = -1;
+
+  return add (a, b);
+}


### PR DESCRIPTION
We need to create the exported symbols using inline asm instead.

Fixes #43.