### PR TITLE
The 'key' parameter for 'des_set_key()' must be at least 8 bytes long.

### DIFF
--- a/alg-des.c
+++ b/alg-des.c
@@ -71,13 +71,14 @@ static const uint8_t key_shifts[16] =
 };
 
 void
-des_set_key (struct des_ctx *restrict ctx, const unsigned char *key)
+des_set_key (struct des_ctx *restrict ctx,
+             const unsigned char key[MIN_SIZE(8)])
 {
   uint32_t rawkey0, rawkey1, k0, k1, t0, t1;
   int shifts, round;
 
-  rawkey0 = be32_to_cpu (key);
-  rawkey1 = be32_to_cpu (key + 4);
+  rawkey0 = be32_to_cpu (&key[0]);
+  rawkey1 = be32_to_cpu (&key[4]);
 
   /* Do key permutation and split into two 28-bit subkeys.  */
   k0 = key_perm_maskl[0][rawkey0 >> 25]

--- a/alg-des.c
+++ b/alg-des.c
@@ -81,19 +81,19 @@ des_set_key (struct des_ctx *restrict ctx,
   rawkey1 = be32_to_cpu (&key[4]);
 
   /* Do key permutation and split into two 28-bit subkeys.  */
-  k0 = key_perm_maskl[0][rawkey0 >> 25]
+  k0 = key_perm_maskl[0][(rawkey0 >> 25) & 0x7f]
        | key_perm_maskl[1][(rawkey0 >> 17) & 0x7f]
        | key_perm_maskl[2][(rawkey0 >> 9) & 0x7f]
        | key_perm_maskl[3][(rawkey0 >> 1) & 0x7f]
-       | key_perm_maskl[4][rawkey1 >> 25]
+       | key_perm_maskl[4][(rawkey1 >> 25) & 0x7f]
        | key_perm_maskl[5][(rawkey1 >> 17) & 0x7f]
        | key_perm_maskl[6][(rawkey1 >> 9) & 0x7f]
        | key_perm_maskl[7][(rawkey1 >> 1) & 0x7f];
-  k1 = key_perm_maskr[0][rawkey0 >> 25]
+  k1 = key_perm_maskr[0][(rawkey0 >> 25) & 0x7f]
        | key_perm_maskr[1][(rawkey0 >> 17) & 0x7f]
        | key_perm_maskr[2][(rawkey0 >> 9) & 0x7f]
        | key_perm_maskr[3][(rawkey0 >> 1) & 0x7f]
-       | key_perm_maskr[4][rawkey1 >> 25]
+       | key_perm_maskr[4][(rawkey1 >> 25) & 0x7f]
        | key_perm_maskr[5][(rawkey1 >> 17) & 0x7f]
        | key_perm_maskr[6][(rawkey1 >> 9) & 0x7f]
        | key_perm_maskr[7][(rawkey1 >> 1) & 0x7f];

--- a/alg-des.h
+++ b/alg-des.h
@@ -56,7 +56,7 @@ struct des_ctx
 };
 
 extern void des_set_key (struct des_ctx *restrict ctx,
-                         const unsigned char *key);
+                         const unsigned char key[MIN_SIZE(8)]);
 extern void des_set_salt (struct des_ctx *restrict ctx,
                           uint32_t salt);
 extern void des_crypt_block (struct des_ctx *restrict ctx,


### PR DESCRIPTION
Coverity scan complains that tainted data can be stored in 'rawkey1'.  Since there are excactly 8 bytes of data accessed, we should enforce this as a minimum parameter length.