### PR TITLE
Optimization to remove logically dead code in most configurations.

### DIFF
--- a/crypt.c
+++ b/crypt.c
@@ -263,14 +263,16 @@ crypt_gensalt_rn (const char *prefix, unsigned long count,
 
   /* If the prefix is 0, that means to use the current best default.
      Note that this is different from the behavior when the prefix is
-     "", which selects DES.  HASH_ALGORITHM_DEFAULT is null when the
-     current default algorithm was disabled at configure time.  */
-  if (!prefix)
-    prefix = HASH_ALGORITHM_DEFAULT;
+     "", which selects DES.  HASH_ALGORITHM_DEFAULT is not defined when
+     the current default algorithm was disabled at configure time.  */
   if (!prefix)
     {
+#if defined HASH_ALGORITHM_DEFAULT
+      prefix = HASH_ALGORITHM_DEFAULT;
+#else
       errno = EINVAL;
       return 0;
+#endif
     }
 
   const struct hashfn *h = get_hashfn (prefix);

--- a/gen-hashes.awk
+++ b/gen-hashes.awk
@@ -156,8 +156,6 @@ END {
     print ""
     if (hash_enabled[default_hash]) {
         print "#define HASH_ALGORITHM_DEFAULT \"" default_prefix "\""
-    } else {
-        print "#define HASH_ALGORITHM_DEFAULT 0"
     }
     print ""
     print "#endif /* crypt-hashes.h */"


### PR DESCRIPTION
Coverity Scan complains about some code path cannot be reached in most configurations.  Thus we should change the logic of the conditional to avoid it.