### PR TITLE
Drop code under #if HAVE_POSIX_MEMALIGN.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,11 +21,6 @@ It was last updated 20 October 2018.
   * Make sure the symbol versioning macros work with all of the
     compilers that anyone needs (they use GCC extensions that clang
     also supports).
-  * `alg-yescrypt-common.c` contains #ifdeffage for use of
-    `posix_memalign` that isn’t wired up to autoconf
-    * possibly this should just be removed; does anything have
-      `posix_memalign` but not `mmap`? it’s only a compile-time
-      fallback, not a runtime fallback
 
 * Hardening
   * bcrypt-like selftest/memory scribble for all hashing methods

--- a/alg-yescrypt-platform.c
+++ b/alg-yescrypt-platform.c
@@ -66,11 +66,7 @@ static void *alloc_region(yescrypt_region_t *region, size_t size)
 	if (base == MAP_FAILED)
 		base = NULL;
 	aligned = base;
-#elif defined(HAVE_POSIX_MEMALIGN)
-	if ((errno = posix_memalign((void **)&base, 64, size)) != 0)
-		base = NULL;
-	aligned = base;
-#else
+#else /* mmap not available */
 	base = aligned = NULL;
 	if (size + 63 < size) {
 		errno = ENOMEM;


### PR DESCRIPTION
alg-yescrypt-platform.c contains code to use posix_memalign if mmap is
unavailable, but it’s not properly wired up to autoconf, so it never
actually gets used.  I don’t think it’s worth keeping, because any
system that bothers to supply posix_memalign probably also has mmap.

I'd like @solardiz to comment on this change.

(This addresses one of the issues described in #30.)