### PR TITLE
Move helper functions into 'crypt-common.c'.

### DIFF
--- a/LICENSING
+++ b/LICENSING
@@ -53,7 +53,7 @@ source tree.  For specific licensing terms consult the files themselves.
    crypt-scrypt.c
 
  * Copyright Björn Esser; 0-clause BSD:
-   test-compile-strong-alias.c test-short-outbuf.c
+   crypt-common.c test-compile-strong-alias.c test-short-outbuf.c
 
  * Copyright Michael Bretterklieber, Björn Esser et al.; 2-clause BSD:
    crypt-nthash.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,7 @@ libcrypt_la_SOURCES = \
 	crypt-gensalt-static.c crypt-gensalt.c crypt-gost-yescrypt.c \
 	crypt-md5.c crypt-nthash.c crypt-pbkdf1-sha1.c crypt-scrypt.c \
 	crypt-sha256.c crypt-sha512.c crypt-static.c crypt-sunmd5.c \
-	crypt-yescrypt.c randombytes.c
+	crypt-yescrypt.c randombytes.c crypt-common.c
 
 EXTRA_DIST += alg-yescrypt-platform.c
 
@@ -220,7 +220,7 @@ test_crypt_sunmd5_LDADD = libcrypt.la
 test_crypt_yescrypt_LDADD = libcrypt.la
 test_badsalt_LDADD = libcrypt.la
 test_badsetting_LDADD = libcrypt.la
-test_gensalt_LDADD = libcrypt.la
+test_gensalt_LDADD = crypt-common.lo libcrypt.la
 test_des_obsolete_LDADD = libcrypt.la
 test_des_obsolete_r_LDADD = libcrypt.la
 test_crypt_badargs_LDADD = libcrypt.la
@@ -243,7 +243,7 @@ test_alg_sha512_LDADD = alg-sha512.lo
 test_crypt_gost_yescrypt_LDADD = alg-gost3411-2012-core.lo \
 	alg-gost3411-2012-hmac.lo alg-sha256.lo \
 	alg-yescrypt-common.lo alg-yescrypt-opt.lo \
-	crypt-yescrypt.lo libcrypt.la
+	crypt-yescrypt.lo crypt-common.lo libcrypt.la
 
 test_getrandom_interface_LDADD = randombytes.lo
 test_getrandom_fallbacks_LDADD = randombytes.lo

--- a/crypt-common.c
+++ b/crypt-common.c
@@ -1,0 +1,50 @@
+/* Copyright (C) 2018 Björn Esser <besser82@fedoraproject.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/* Simple commonly used helper functions.  */
+
+#include "crypt-port.h"
+
+/* Provide a safe way to copy strings with the guarantee src,
+   including its terminating '\0', will fit d_size bytes.
+   The trailing bytes of d_size will be filled with '\0'.
+   dst and src must not be NULL.  Returns strlen (src).  */
+size_t
+_crypt_strcpy_or_abort (void *dst, const size_t d_size,
+                        const void *src)
+{
+  assert (dst != NULL);
+  assert (src != NULL);
+  const size_t s_size = strlen ((const char *) src);
+  assert (d_size >= s_size + 1);
+  memcpy (dst, src, s_size);
+  XCRYPT_SECURE_MEMSET ((char *) dst + s_size, d_size - s_size);
+  return s_size;
+}
+
+#if INCLUDE_XCRYPT_SECURE_MEMSET
+/* The best hope we without any other implementation to
+   securely wipe data stored in memory.  */
+void
+_crypt_secure_memset (void *s, size_t len)
+{
+  volatile unsigned char *c = s;
+  while (len--)
+    *c++ = 0x00;
+}
+#endif

--- a/crypt-port.h
+++ b/crypt-port.h
@@ -138,35 +138,24 @@ typedef union
   explicit_memset (s, 0x00, len)
 #else
 /* The best hope we have in this case.  */
-static inline void
-_xcrypt_secure_memset (void *s, size_t len)
-{
-  volatile unsigned char *c = s;
-  while (len--)
-    *c++ = 0x00;
-}
+#define INCLUDE_XCRYPT_SECURE_MEMSET 1
+extern void _crypt_secure_memset (s, len);
 #define XCRYPT_SECURE_MEMSET(s, len) \
-  _xcrypt_secure_memset (s, len)
+  _crypt_secure_memset (s, len)
+#endif
+#ifndef INCLUDE_XCRYPT_SECURE_MEMSET
+#define INCLUDE_XCRYPT_SECURE_MEMSET 0
 #endif
 
 /* Provide a safe way to copy strings with the guarantee src,
    including its terminating '\0', will fit d_size bytes.
    The trailing bytes of d_size will be filled with '\0'.
    dst and src must not be NULL.  Returns strlen (src).  */
-static inline size_t
-_xcrypt_strcpy_or_abort (void *dst, const size_t d_size,
-                         const void *src)
-{
-  assert (dst != NULL);
-  assert (src != NULL);
-  const size_t s_size = strlen ((const char *) src);
-  assert (d_size >= s_size + 1);
-  memcpy (dst, src, s_size);
-  XCRYPT_SECURE_MEMSET ((char *) dst + s_size, d_size - s_size);
-  return s_size;
-}
+extern size_t
+_crypt_strcpy_or_abort (void *dst, const size_t d_size,
+                        const void *src);
 #define XCRYPT_STRCPY_OR_ABORT(dst, d_size, src) \
-  _xcrypt_strcpy_or_abort (dst, d_size, src)
+  _crypt_strcpy_or_abort (dst, d_size, src)
 
 /* Per-symbol version tagging.  Currently we only know how to do this
    using GCC extensions.  */


### PR DESCRIPTION
Inlining these functions into exery compilation unit take time and wastes space in the library.  Additonally some compilers complain about unused inline functions.