### PR TITLE
Configure the value of 'CRYPT_GENSALT_IMPLEMENTS_DEFAULT_PREFIX'.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -116,6 +116,10 @@ crypt.h: crypt.h.in crypt-hashes.h crypt-symbol-vers.h gen-crypt-h.awk config.h
 	$(AM_V_GEN)LC_ALL=C $(AWK) \
 	  -f $(srcdir)/gen-crypt-h.awk config.h $(builddir)/crypt.h.in \
 	  > crypt.h.T
+	$(AM_V_GEN)LC_ALL=C \
+	$(GREP) -q "#define HASH_ALGORITHM_DEFAULT" crypt-hashes.h && \
+	$(SED) -i -e "s/@DEFAULT_PREFIX_ENABLED@/1/g" crypt.h.T || \
+	$(SED) -i -e "s/@DEFAULT_PREFIX_ENABLED@/0/g" crypt.h.T
 	$(AM_V_at)mv -f crypt.h.T crypt.h
 
 crypt-hashes.h: hashes.lst gen-hashes.awk Makefile

--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,8 @@ Version 4.3.0
   at compile time.
 * Implement crypt_checksalt, which can be used by portable users of
   libxcrypt to check whether the desired hash method is supported.
+* Fix the definition of 'CRYPT_GENSALT_IMPLEMENTS_DEFAULT_PREFIX'
+  to reflect whether the default prefix is available or not.
 
 Version 4.2.3
 * Add bootstrap script.  If building from a Git checkout instead of a

--- a/crypt.h.in.in
+++ b/crypt.h.in.in
@@ -202,7 +202,7 @@ extern int crypt_checksalt (const char *__setting);
 /* These macros could be checked by portable users of crypt_gensalt*
    functions to find out whether null pointers could be specified
    as PREFIX and RBYTES arguments.  */
-#define CRYPT_GENSALT_IMPLEMENTS_DEFAULT_PREFIX 1
+#define CRYPT_GENSALT_IMPLEMENTS_DEFAULT_PREFIX @DEFAULT_PREFIX_ENABLED@
 #define CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY   1
 
 /* These macros can be checked by portable users of the crypt_checksalt


### PR DESCRIPTION
The constant must only be defined to '1', if the default hashing method is enabled in the configuration.
Otherwise it must be defined to '0'.