### PR TITLE
Add an alias for crypt_gensalt_r.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@ Please send bug reports, questions and suggestions to
 <https://github.com/besser82/libxcrypt/issues>.
 
 Version 4.3.3
+* Add an alias for crypt_gensalt_r.
+  The function was available in older versions (v3.1.1 and earlier)
+  of libxcrypt.  It has the same semantics and the same prototype as
+  the crypt_gensalt_rn function.
 
 Version 4.3.2
 * Fix the gensalt function for the NT hashing method ($3$) to

--- a/crypt.c
+++ b/crypt.c
@@ -315,6 +315,12 @@ crypt_gensalt_rn (const char *prefix, unsigned long count,
   return output[0] == '*' ? 0 : output;
 }
 SYMVER_crypt_gensalt_rn;
+
+#if INCLUDE_crypt_gensalt_r
+/* For code compatibility with older versions (v3.1.1 and earlier).  */
+strong_alias (crypt_gensalt_rn, crypt_gensalt_r);
+SYMVER_crypt_gensalt_r;
+#endif
 #endif
 
 #if INCLUDE_crypt_gensalt_ra

--- a/crypt.h.in.in
+++ b/crypt.h.in.in
@@ -178,6 +178,13 @@ extern char *crypt_gensalt_rn (const char *__prefix, unsigned long __count,
                                char *__output, int __output_size)
 __THROW;
 
+/* Identical to crypt_gensalt_rn.  Kept for code compatibility with
+   older versions (v3.1.1 and earlier) of libxcrypt.  */
+extern char *crypt_gensalt_r (const char *__prefix, unsigned long __count,
+                              const char *__rbytes, int __nrbytes,
+                              char *__output, int __output_size)
+__THROW;
+
 /* Another thread-safe version of crypt_gensalt; the generated setting
    string is in storage allocated by malloc, and should be deallocated
    with free when it is no longer needed.  */

--- a/libcrypt.map.in
+++ b/libcrypt.map.in
@@ -19,6 +19,10 @@ crypt_gensalt_ra	XCRYPT_2.0	GLIBC_2.0:owl:suse	GLIBC_2.2.2:alt     OW_CRYPT_1.0:
 # Actively supported interfaces from libxcrypt.
 crypt_checksalt		XCRYPT_4.3
 
+# Interface for code compatibility with older versions
+# (v3.1.1 and earlier) of libxcrypt.
+crypt_gensalt_r		XCRYPT_2.0
+
 # Deprecated interfaces, POSIX and otherwise; also present in GNU libc
 # since 2.0
 encrypt			-		GLIBC_2.0


### PR DESCRIPTION
The function was available in older versions (v3.1.1 and earlier) of libxcrypt.  It has the same semantics and the same prototype as the crypt_gensalt_rn function.

Adding such an alias makes porting applications written for those earlier versions of libxcrypt much easier and requires less conditionals to keep code compatibility for systems still using an antique release.