### PR TITLE
Add aliases for xcrypt{,_r} and xcrypt_gensalt{,_r}.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,6 @@ notrans_dist_man3_MANS = \
 	crypt_gensalt_rn.3
 notrans_dist_man5_MANS = crypt.5
 
-include_HEADERS = xcrypt.h
 nodist_include_HEADERS = crypt.h
 nodist_noinst_HEADERS = crypt-hashes.h crypt-symbol-vers.h
 noinst_HEADERS = \
@@ -35,6 +34,13 @@ noinst_HEADERS = \
 	alg-sha1.h alg-sha256.h alg-sha512.h alg-yescrypt.h \
 	alg-yescrypt-sysendian.h byteorder.h crypt-obsolete.h \
 	crypt-port.h test-des-cases.h
+
+if ENABLE_XCRYPT_COMPAT_FILES
+include_HEADERS = xcrypt.h
+else
+noinst_HEADERS += xcrypt.h
+endif
+
 
 noinst_PROGRAMS = gen-des-tables
 
@@ -52,6 +58,7 @@ libcrypt_la_SOURCES = \
 EXTRA_DIST += alg-yescrypt-platform.c
 
 pkgconfig_DATA = libxcrypt.pc
+
 # Install libcrypt.pc symlink to libxcrypt.pc file.
 phony_targets = \
 	install-data-hook-pkgconfig uninstall-hook-pkgconfig
@@ -129,6 +136,40 @@ crypt-hashes.h: hashes.lst gen-hashes.awk Makefile
 	  $(srcdir)/hashes.lst > crypt-hashes.h.T
 	$(AM_V_at)mv -f crypt-hashes.h.T crypt-hashes.h
 
+install_exec_hook_targets =
+
+if ENABLE_XCRYPT_COMPAT_FILES
+if ENABLE_STATIC
+# Install libxcrypt.a symlink to libcrypt.a file.
+phony_targets += \
+	install-exec-hook-xcrypt-static uninstall-hook-xcrypt-static
+install_exec_hook_targets += \
+	install-exec-hook-xcrypt-static
+uninstall_hook_targets += \
+	uninstall-hook-xcrypt-static
+install-exec-hook-xcrypt-static:
+	cd $(DESTDIR)$(libdir) && \
+		$(LN_S) libcrypt.a libxcrypt.a
+uninstall-hook-xcrypt-static:
+	-rm -f $(DESTDIR)$(libdir)/libxcrypt.a
+endif
+
+if ENABLE_SHARED
+# Install libxcrypt.so symlink to libcrypt.so file.
+phony_targets += \
+	install-exec-hook-xcrypt-shared uninstall-hook-xcrypt-shared
+install_exec_hook_targets += \
+	install-exec-hook-xcrypt-shared
+uninstall_hook_targets += \
+	uninstall-hook-xcrypt-shared
+install-exec-hook-xcrypt-shared:
+	cd $(DESTDIR)$(libdir) && \
+		$(LN_S) libcrypt.so libxcrypt.so
+uninstall-hook-xcrypt-shared:
+	-rm -f $(DESTDIR)$(libdir)/libxcrypt.so
+endif
+endif
+
 if ENABLE_COMPAT_SUSE
 # When we are being binary compatible, also install symbolic links to
 # mimic SUSE's libowcrypt; any program that uses -lowcrypt in its
@@ -146,7 +187,8 @@ if ENABLE_OBSOLETE_API
 if ENABLE_STATIC
 phony_targets += \
 	install-exec-hook-libstatic uninstall-hook-libstatic
-install-exec-hook: install-exec-hook-libstatic
+install_exec_hook_targets += \
+	install-exec-hook-libstatic
 uninstall_hook_targets += \
 	uninstall-hook-libstatic
 install-exec-hook-libstatic:
@@ -158,7 +200,8 @@ endif
 if ENABLE_SHARED
 phony_targets += \
 	install-exec-hook-libshared uninstall-hook-libshared
-install-exec-hook: install-exec-hook-libshared
+install_exec_hook_targets += \
+	install-exec-hook-libshared
 uninstall_hook_targets += \
 	uninstall-hook-libshared
 install-exec-hook-libshared:
@@ -268,4 +311,5 @@ include $(builddir)/Makefile.deps
 
 # Add additional targets
 .PHONY: $(phony_targets)
+install-exec-hook: $(install_exec_hook_targets)
 uninstall-hook: $(uninstall_hook_targets)

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,7 @@ notrans_dist_man3_MANS = \
 	crypt_gensalt_rn.3
 notrans_dist_man5_MANS = crypt.5
 
+include_HEADERS = xcrypt.h
 nodist_include_HEADERS = crypt.h
 nodist_noinst_HEADERS = crypt-hashes.h crypt-symbol-vers.h
 noinst_HEADERS = \

--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,13 @@ Version 4.3.4
 * Add aliases for xcrypt{,_r} and xcrypt_gensalt{,_r}.
   They were added for code compatibility with libxcrypt v3.1.1
   and earlier.
+* Install the <xcrypt.h> header file, declaring the previously named
+  aliases, and a symlink from libxcrypt.so to libcrypt.so, if a shared
+  library is build.  For static libraries a corresponding symlink for
+  the archive file will be installed.
+  The installation of the compatibility files can be disabled by
+  passing the '--disable-xcrypt-compat-files' flag to the configure
+  script.
 * Replace the prototype for the crypt_gensalt_r function with a
   declaration through a macro, so new compiled applications link
   against the identical crypt_gensalt_rn function directly.

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,12 @@ Please send bug reports, questions and suggestions to
 
 Version 4.3.4
 * --enable-hashes now supports 'fedora' as a group of hashing methods.
+* Add aliases for xcrypt{,_r} and xcrypt_gensalt{,_r}.
+  They were added for code compatibility with libxcrypt v3.1.1
+  and earlier.
+* Replace the prototype for the crypt_gensalt_r function with a
+  declaration through a macro, so new compiled applications link
+  against the identical crypt_gensalt_rn function directly.
 
 Version 4.3.3
 * Add an alias for crypt_gensalt_r.

--- a/configure.ac
+++ b/configure.ac
@@ -212,6 +212,20 @@ AC_DEFINE_UNQUOTED([ENABLE_FAILURE_TOKENS], [$enable_failure_tokens],
   [Define to 1 if crypt and crypt_r should return a "failure token" on
    failure, or 0 if they should return NULL.])
 
+AC_ARG_ENABLE([xcrypt-compat-files],
+    AS_HELP_STRING(
+        [--disable-xcrypt-compat-files],
+        [Disable the installation of the <xcrypt.h> header file and the
+         libxcrypt.{a,so} compatibility symlinks.]
+    ),
+    [case "$enableval" in
+      yes) enable_xcrypt_compat_files=1;;
+       no) enable_xcrypt_compat_files=0;;
+        *) AC_MSG_ERROR([bad value ${enableval} for --enable-xcrypt-compat-files]);;
+     esac],
+    [enable_xcrypt_compat_files=1])
+AM_CONDITIONAL([ENABLE_XCRYPT_COMPAT_FILES], [test x"$enable_xcrypt_compat_files" = x1])
+
 AC_ARG_ENABLE([obsolete-api],
     AS_HELP_STRING(
         [--enable-obsolete-api[=ARG]],

--- a/crypt-gensalt-static.c
+++ b/crypt-gensalt-static.c
@@ -15,6 +15,7 @@
    <https://www.gnu.org/licenses/>.  */
 
 #include "crypt-port.h"
+#include "xcrypt.h"
 
 /* The functions that use global state objects are isolated in their
    own files so that a statically-linked program that doesn't use them
@@ -31,4 +32,10 @@ crypt_gensalt (const char *prefix, unsigned long count,
                            rbytes, nrbytes, output, sizeof (output));
 }
 SYMVER_crypt_gensalt;
+#endif
+
+/* For code compatibility with older versions (v3.1.1 and earlier).  */
+#if INCLUDE_crypt_gensalt && INCLUDE_xcrypt_gensalt
+strong_alias (crypt_gensalt, xcrypt_gensalt);
+SYMVER_xcrypt_gensalt;
 #endif

--- a/crypt-static.c
+++ b/crypt-static.c
@@ -15,6 +15,7 @@
    <https://www.gnu.org/licenses/>.  */
 
 #include "crypt-port.h"
+#include "xcrypt.h"
 
 /* The functions that use global state objects are isolated in their
    own files so that a statically-linked program that doesn't use them
@@ -36,4 +37,10 @@ SYMVER_crypt;
 #if INCLUDE_fcrypt
 strong_alias (crypt, fcrypt);
 SYMVER_fcrypt;
+#endif
+
+/* For code compatibility with older versions (v3.1.1 and earlier).  */
+#if INCLUDE_crypt && INCLUDE_xcrypt
+strong_alias (crypt, xcrypt);
+SYMVER_xcrypt;
 #endif

--- a/crypt.c
+++ b/crypt.c
@@ -17,6 +17,7 @@
    <https://www.gnu.org/licenses/>.  */
 
 #include "crypt-port.h"
+#include "xcrypt.h"
 
 #include <errno.h>
 #include <stdlib.h>
@@ -242,6 +243,12 @@ crypt_r (const char *phrase, const char *setting, struct crypt_data *data)
 SYMVER_crypt_r;
 #endif
 
+/* For code compatibility with older versions (v3.1.1 and earlier).  */
+#if INCLUDE_crypt_r && INCLUDE_xcrypt_r
+strong_alias (crypt_r, xcrypt_r);
+SYMVER_xcrypt_r;
+#endif
+
 #if INCLUDE_crypt_gensalt_rn
 char *
 crypt_gensalt_rn (const char *prefix, unsigned long count,
@@ -315,12 +322,18 @@ crypt_gensalt_rn (const char *prefix, unsigned long count,
   return output[0] == '*' ? 0 : output;
 }
 SYMVER_crypt_gensalt_rn;
+#endif
 
-#if INCLUDE_crypt_gensalt_r
 /* For code compatibility with older versions (v3.1.1 and earlier).  */
+#if INCLUDE_crypt_gensalt_rn && INCLUDE_crypt_gensalt_r
 strong_alias (crypt_gensalt_rn, crypt_gensalt_r);
 SYMVER_crypt_gensalt_r;
 #endif
+
+/* For code compatibility with older versions (v3.1.1 and earlier).  */
+#if INCLUDE_crypt_gensalt_rn && INCLUDE_xcrypt_gensalt_r
+strong_alias (crypt_gensalt_rn, xcrypt_gensalt_r);
+SYMVER_xcrypt_gensalt_r;
 #endif
 
 #if INCLUDE_crypt_gensalt_ra

--- a/crypt.h.in.in
+++ b/crypt.h.in.in
@@ -178,12 +178,20 @@ extern char *crypt_gensalt_rn (const char *__prefix, unsigned long __count,
                                char *__output, int __output_size)
 __THROW;
 
-/* Identical to crypt_gensalt_rn.  Kept for code compatibility with
-   older versions (v3.1.1 and earlier) of libxcrypt.  */
-extern char *crypt_gensalt_r (const char *__prefix, unsigned long __count,
-                              const char *__rbytes, int __nrbytes,
-                              char *__output, int __output_size)
-__THROW;
+/* Kept for code compatibility with libxcrypt (v3.1.1 and earlier).
+   We intentionally declare the function using a macro here, since
+   we actually want to link compiled applications against the
+   identical crypt_gensalt_rn function.  */
+#ifndef IN_LIBCRYPT  /* Defined when building libxcrypt. */
+# ifdef __REDIRECT_NTH
+extern char * __REDIRECT_NTH (crypt_gensalt_r, (const char *__prefix,
+                              unsigned long __count, const char *__rbytes,
+                              int __nrbytes, char *__output,
+                              int __output_size), crypt_gensalt_rn);
+# else
+#  define crypt_gensalt_r crypt_gensalt_rn
+# endif
+#endif
 
 /* Another thread-safe version of crypt_gensalt; the generated setting
    string is in storage allocated by malloc, and should be deallocated

--- a/libcrypt.map.in
+++ b/libcrypt.map.in
@@ -19,9 +19,15 @@ crypt_gensalt_ra	XCRYPT_2.0	GLIBC_2.0:owl:suse	GLIBC_2.2.2:alt     OW_CRYPT_1.0:
 # Actively supported interfaces from libxcrypt.
 crypt_checksalt		XCRYPT_4.3
 
-# Interface for code compatibility with older versions
-# (v3.1.1 and earlier) of libxcrypt.
+# Interfaces for code compatibility with libxcrypt v3.1.1 and earlier.
+# They need to be exported as default symbols, although we take care they
+# are not linked by new compiled applications, so functions with similar
+# semantics of AC_CHECK_FUNCS will detect them as available.
 crypt_gensalt_r		XCRYPT_2.0
+xcrypt			XCRYPT_2.0
+xcrypt_r		XCRYPT_2.0
+xcrypt_gensalt		XCRYPT_2.0
+xcrypt_gensalt_r	XCRYPT_2.0
 
 # Deprecated interfaces, POSIX and otherwise; also present in GNU libc
 # since 2.0

--- a/xcrypt.h
+++ b/xcrypt.h
@@ -1,0 +1,55 @@
+/* libxcrypt interfaces for code compatibility.
+
+   Copyright (C) 2018 Björn Esser <besser82@fedoraproject.org>
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted.
+
+   THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+   OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+   OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+   SUCH DAMAGE.  */
+
+#ifndef _XCRYPT_H
+#define _XCRYPT_H 1
+
+#include <crypt.h>
+
+/* Those are kept for code compatibility with older versions
+   (v3.1.1 and earlier) of libxcrypt.
+   We intentionally declare these functions using macros here,
+   since we actually want to link compiled applications against
+   the unprefixed indentical functions defined in <crypt.h>.  */
+#ifndef IN_LIBCRYPT  /* Defined when building libxcrypt. */
+# ifdef __REDIRECT_NTH
+extern char * __REDIRECT_NTH (xcrypt, (const char *__phrase,
+                              const char *__setting), crypt);
+
+extern char * __REDIRECT_NTH (xcrypt_r, (const char *__phrase,
+                              const char *__setting,
+                              struct crypt_data *__restrict __data), crypt_r);
+
+extern char * __REDIRECT_NTH (xcrypt_gensalt, (const char *__prefix,
+                              unsigned long __count, const char *__rbytes,
+                              int __nrbytes), crypt_gensalt);
+
+extern char * __REDIRECT_NTH (xcrypt_gensalt_r, (const char *__prefix,
+                              unsigned long __count, const char *__rbytes,
+                              int __nrbytes, char *__output,
+                              int __output_size), crypt_gensalt_rn);
+# else
+#  define xcrypt           crypt
+#  define xcrypt_r         crypt_r
+#  define xcrypt_gensalt   crypt_gensalt
+#  define xcrypt_gensalt_r crypt_gensalt_rn
+# endif
+#endif
+
+#endif /* xcrypt.h */


### PR DESCRIPTION
Those aliases were added for code compatibility with libxcrypt v3.1.1 and earlier.

Also replace the prototype for the crypt_gensalt_r function with a macro, so new compiled applications link against the identical crypt_gensalt_rn function directly.