### PR TITLE
Add 'fedora' to the groups of hashing methods.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@ Please send bug reports, questions and suggestions to
 <https://github.com/besser82/libxcrypt/issues>.
 
 Version 4.3.4
+* --enable-hashes now supports 'fedora' as a group of hashing methods.
 
 Version 4.3.3
 * Add an alias for crypt_gensalt_r.

--- a/gen-hashes.awk
+++ b/gen-hashes.awk
@@ -84,10 +84,11 @@ BEGIN {
         if (flag == "DEFAULT") {
             default_cand[$1] = $2
         } else if (flag == "STRONG"  || flag == "GLIBC"   || \
-                   flag == "ALT"     || flag == "FREEBSD" || \
-                   flag == "NETBSD"  || flag == "OPENBSD" || \
-                   flag == "OSX"     || flag == "OWL"     || \
-                   flag == "SOLARIS" || flag == "SUSE") {
+                   flag == "ALT"     || flag == "FEDORA"  || \
+                   flag == "FREEBSD" || flag == "NETBSD"  || \
+                   flag == "OPENBSD" || flag == "OSX"     || \
+                   flag == "OWL"     || flag == "SOLARIS" || \
+                   flag == "SUSE") {
             # handled in sel-hashes.awk
         } else {
             printf("%s:%d: unrecognized flag %s\n", FILENAME, NR, flag) \

--- a/hashes.lst
+++ b/hashes.lst
@@ -39,7 +39,7 @@
 # supported hashes).
 #
 #name          h_prefix  nrbytes  flags
-yescrypt       $y$       16       STRONG,DEFAULT,ALT
+yescrypt       $y$       16       STRONG,DEFAULT,ALT,FEDORA
 gost_yescrypt  $gy$      16       STRONG,ALT
 scrypt         $7$       16       STRONG
 bcrypt         $2b$      16       STRONG,DEFAULT,ALT,FREEBSD,NETBSD,OPENBSD,OWL,SOLARIS,SUSE

--- a/sel-hashes.awk
+++ b/sel-hashes.awk
@@ -22,6 +22,7 @@ BEGIN {
     enable_strong    = 0
     enable_glibc     = 0
     enable_alt       = 0
+    enable_fedora    = 0
     enable_freebsd   = 0
     enable_netbsd    = 0
     enable_openbsd   = 0
@@ -41,6 +42,8 @@ BEGIN {
             enable_glibc = 1
         } else if (h == "alt") {
             enable_alt = 1
+        } else if (h == "fedora") {
+            enable_fedora = 1
         } else if (h == "freebsd") {
             enable_freebsd = 1
         } else if (h == "netbsd") {
@@ -60,10 +63,10 @@ BEGIN {
             selected_hashes[h] = 1
         }
     }
-    if (enable_all && (enable_strong  || enable_glibc   || enable_some   || \
-                       enable_alt     || enable_freebsd || enable_netbsd || \
-                       enable_openbsd || enable_osx     || enable_owl    || \
-                       enable_solaris || enable_suse)) {
+    if (enable_all && (enable_strong  || enable_glibc   || enable_some    || \
+                       enable_alt     || enable_fedora  || enable_freebsd || \
+                       enable_netbsd  || enable_openbsd || enable_osx     || \
+                       enable_owl     || enable_solaris || enable_suse)) {
         error = 1
         exit 1
     }
@@ -87,6 +90,8 @@ BEGIN {
             } else if (flag == "GLIBC" && enable_glibc) {
                 enabled_hashes[$1] = 1
             } else if (flag == "ALT" && enable_alt) {
+                enabled_hashes[$1] = 1
+            } else if (flag == "FEDORA" && enable_fedora) {
                 enabled_hashes[$1] = 1
             } else if (flag == "FREEBSD" && enable_freebsd) {
                 enabled_hashes[$1] = 1


### PR DESCRIPTION
--enable-hashes now supports 'fedora' as a group of hashing methods.