### PR TITLE
Implement the crypt_preferred_method function.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@
 /test-gensalt-extradata
 /test-getrandom-fallbacks
 /test-getrandom-interface
+/test-preferred-method
 /test-short-outbuf
 
 # backup-files

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@ EXTRA_DIST = \
 notrans_dist_man3_MANS = \
 	crypt.3 crypt_r.3 crypt_ra.3 crypt_rn.3 \
 	crypt_checksalt.3 crypt_gensalt.3 crypt_gensalt_ra.3 \
-	crypt_gensalt_rn.3
+	crypt_gensalt_rn.3 crypt_preferred_method.3
 notrans_dist_man5_MANS = crypt.5
 
 nodist_include_HEADERS = crypt.h
@@ -226,7 +226,7 @@ check_PROGRAMS = \
 	test-crypt-pbkdf1-sha1 test-crypt-scrypt test-crypt-sha256 \
 	test-crypt-sha512 test-crypt-sunmd5 test-crypt-yescrypt \
 	test-byteorder test-badsalt test-badsetting test-gensalt \
-	test-gensalt-extradata \
+	test-gensalt-extradata test-preferred-method \
 	test-crypt-badargs test-short-outbuf test-compile-strong-alias \
         test-getrandom-interface test-getrandom-fallbacks
 
@@ -288,6 +288,7 @@ test_des_obsolete_LDADD = $(COMMON_TEST_OBJECTS)
 test_des_obsolete_r_LDADD = $(COMMON_TEST_OBJECTS)
 test_crypt_badargs_LDADD = $(COMMON_TEST_OBJECTS)
 test_short_outbuf_LDADD = $(COMMON_TEST_OBJECTS)
+test_preferred_method_LDADD = $(COMMON_TEST_OBJECTS)
 
 # These tests call internal APIs that may not be accessible from the
 # fully linked shared library.

--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,10 @@ libxcrypt NEWS -- history of user-visible changes.
 Please send bug reports, questions and suggestions to
 <https://github.com/besser82/libxcrypt/issues>.
 
-Version 4.3.5
+Version 4.4.0
+* Implement the crypt_preferred_method function.
+  This function can be used as a convenience function to get the prefix
+  of the preferred hash method.
 
 Version 4.3.4
 * --enable-hashes now supports 'fedora' as a group of hashing methods.

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Process this file with autoconf to produce a configure script.
 m4_include([m4/zw_automodern.m4])
 AC_INIT([xcrypt],
-        [4.3.5],
+        [4.4.0],
         [https://github.com/besser82/libxcrypt/issues],
         [libxcrypt],
         [https://github.com/besser82/libxcrypt])

--- a/crypt.c
+++ b/crypt.c
@@ -374,3 +374,16 @@ crypt_checksalt (const char *setting)
 }
 SYMVER_crypt_checksalt;
 #endif
+
+#if INCLUDE_crypt_preferred_method
+const char *
+crypt_preferred_method (void)
+{
+#if defined HASH_ALGORITHM_DEFAULT
+      return HASH_ALGORITHM_DEFAULT;
+#else
+      return NULL;
+#endif
+}
+SYMVER_crypt_preferred_method;
+#endif

--- a/crypt.h.in.in
+++ b/crypt.h.in.in
@@ -214,15 +214,24 @@ extern int crypt_checksalt (const char *__setting);
 #define CRYPT_SALT_METHOD_LEGACY   3  /* NOT implemented, yet. */
 #define CRYPT_SALT_TOO_CHEAP       4  /* NOT implemented, yet. */
 
+/* Convenience function to get the prefix of the preferred hash method,
+   which is also used by the crypt_gensalt functions, if their given
+   prefix parameter is NULL.
+
+   The return value is string that equals the prefix of the preferred
+   hash method.  Otherwise, it is NULL.  */
+extern const char *crypt_preferred_method (void);
+
 /* These macros could be checked by portable users of crypt_gensalt*
    functions to find out whether null pointers could be specified
    as PREFIX and RBYTES arguments.  */
 #define CRYPT_GENSALT_IMPLEMENTS_DEFAULT_PREFIX @DEFAULT_PREFIX_ENABLED@
 #define CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY   1
 
-/* These macros can be checked by portable users of the crypt_checksalt
-   function to find out whether the function is implemented.  */
+/* These macros can be checked by portable users of libxcrypt
+   to find out whether the function is implemented.  */
 #define CRYPT_CHECKSALT_AVAILABLE 1
+#define CRYPT_PREFERRED_METHOD_AVAILABLE 1
 
 /* Version number split in single integers.  */
 #define XCRYPT_VERSION_MAJOR @XCRYPT_VERSION_MAJOR@

--- a/crypt_preferred_method.3
+++ b/crypt_preferred_method.3
@@ -1,0 +1,67 @@
+.\" Written by Björn Esser <besser82 at fedoraproject.org> in 2018.
+.\"
+.\" To the extent possible under law, the authors have waived
+.\" all copyright and related or neighboring rights to this work.
+.\" See https://creativecommons.org/publicdomain/zero/1.0/ for further
+.\" details.
+.\"
+.Dd November 16, 2018
+.Dt CRYPT_PREFERRED_METHOD 3
+.Os "libxcrypt"
+.Sh NAME
+.Nm crypt_preferred_method
+.Nd get the prefix of the preferred hash method
+.Sh LIBRARY
+.Lb libcrypt
+.Sh SYNOPSIS
+.In crypt.h
+.Ft const char*
+.Fo crypt_preferred_method
+.Fa "void"
+.Fc
+.Sh DESCRIPTION
+.Nm
+is a convenience function to get the prefix of the preferred hash
+method.  If a preferred method is available, it is the same as the
+one also used by the
+.Nm crypt_gensalt functions ,
+if their given
+.Ar prefix
+parameter is NULL.
+.Sh RETURN VALUES
+The string returned equals the prefix of the preferred hash method.
+If no preferred hash method is available it is NULL.  It
+.Em is
+safe to pass the string returned by
+.Nm crypt_preferred_method
+directly to
+.Nm crypt_gensalt
+without prior string-sanitizing nor NULL-pointer checks.
+.El
+.Sh FEATURE TEST MACROS
+.In crypt.h
+will define the macro
+.Dv CRYPT_PREFERRED_METHOD_AVAILABLE
+if
+.Nm
+is available in the current version of libxcrypt.
+.Sh PORTABILITY NOTES
+The function
+.Nm
+is not part of any standard.
+It was added to libxcrypt in version 4.4.0.
+.Sh ATTRIBUTES
+For an explanation of the terms used in this section, see
+.Xr attributes 7 .
+.TS
+allbox;
+lb lb lb
+l l l.
+Interface	Attribute	Value
+T{
+.Nm
+T}	Thread safety	MT-Safe
+.TE
+.sp
+.Sh SEE ALSO
+.Xr crypt_gensalt 3

--- a/libcrypt.map.in
+++ b/libcrypt.map.in
@@ -18,6 +18,7 @@ crypt_gensalt_ra	XCRYPT_2.0	GLIBC_2.0:owl:suse	GLIBC_2.2.2:alt     OW_CRYPT_1.0:
 
 # Actively supported interfaces from libxcrypt.
 crypt_checksalt		XCRYPT_4.3
+crypt_preferred_method	XCRYPT_4.4
 
 # Interfaces for code compatibility with libxcrypt v3.1.1 and earlier.
 # They need to be exported as default symbols, although we take care they
@@ -44,4 +45,4 @@ fcrypt			-		GLIBC_2.0
 %chain GLIBC_2.0 GLIBC_2.2 GLIBC_2.2.1 GLIBC_2.2.2 GLIBC_2.2.5 GLIBC_2.3
 %chain GLIBC_2.4 GLIBC_2.12 GLIBC_2.16 GLIBC_2.17 GLIBC_2.18 GLIBC_2.21
 %chain GLIBC_2.27
-%chain OW_CRYPT_1.0 XCRYPT_2.0 XCRYPT_4.3
+%chain OW_CRYPT_1.0 XCRYPT_2.0 XCRYPT_4.3 XCRYPT_4.4

--- a/test-preferred-method.c
+++ b/test-preferred-method.c
@@ -1,0 +1,133 @@
+/* Copyright (C) 2018 Björn Esser <besser82@fedoraproject.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "crypt-port.h"
+#include <stdio.h>
+
+#define PASSPHRASE "Ob-La-Di, Ob-La-Da"
+
+int
+main (void)
+{
+  const char *pm = crypt_preferred_method();
+  int retval = 0;
+
+#if defined HASH_ALGORITHM_DEFAULT
+  if (pm == NULL)
+    {
+      printf ("FAIL: crypt_preferred_method returned NULL.\n");
+      retval = 1;
+    }
+  else
+    {
+      printf ("PASS: crypt_preferred_method returned \"%s\".\n", pm);
+
+      char gs[CRYPT_GENSALT_OUTPUT_SIZE];
+      struct crypt_data cd;
+
+      crypt_gensalt_rn (NULL, 0, NULL, 0, gs, sizeof (gs));
+
+      if (strncmp (gs, pm, strlen (pm)))
+        {
+          printf ("FAIL: crypt_preferred_method: \"%s\" ", pm);
+          printf ("differs from default prefix.\n");
+          printf ("crypt_gensalt returned: \"%s\".\n", gs);
+          retval = 1;
+        }
+      else
+        {
+          printf ("PASS: crypt_preferred_method: \"%s\" ", pm);
+          printf ("is the same as default prefix used by ");
+          printf ("crypt_gensalt.\n");
+        }
+
+      crypt_gensalt_rn (pm, 0, NULL, 0, gs, sizeof (gs));
+
+      if (gs[0] == '*')
+        {
+          printf ("FAIL: crypt_preferred_method: \"%s\" ", pm);
+          printf ("is not a valid prefix for crypt_gensalt.\n");
+          printf ("crypt_gensalt returned: \"%s\".\n", gs);
+          retval = 1;
+        }
+      else
+        {
+          printf ("PASS: crypt_preferred_method: \"%s\" ", pm);
+          printf ("is a valid prefix for crypt_gensalt.\n");
+        }
+
+      if (strncmp (gs, pm, strlen (pm)))
+        {
+          printf ("FAIL: crypt_preferred_method: \"%s\" ", pm);
+          printf ("does not generate a setting for ");
+          printf ("the intended method.\n");
+          printf ("crypt_gensalt returned: \"%s\".\n", gs);
+          retval = 1;
+        }
+      else
+        {
+          printf ("PASS: crypt_preferred_method: \"%s\" ", pm);
+          printf ("does generate a setting for ");
+          printf ("the intended method.\n");
+        }
+
+      crypt_r (PASSPHRASE, gs, &cd);
+
+      if (cd.output[0] == '*')
+        {
+          printf ("FAIL: crypt_preferred_method: \"%s\" ", pm);
+          printf ("is not a valid prefix for crypt.\n");
+          printf ("crypt returned: \"%s\".\n", gs);
+          retval = 1;
+        }
+      else
+        {
+          printf ("PASS: crypt_preferred_method: \"%s\" ", pm);
+          printf ("is a valid prefix for crypt.\n");
+        }
+
+      if (strncmp (cd.output, pm, strlen (pm)))
+        {
+          printf ("FAIL: crypt_preferred_method: \"%s\" ", pm);
+          printf ("does not generate a hash with ");
+          printf ("the intended method.\n");
+          printf ("crypt returned: \"%s\".\n", gs);
+          retval = 1;
+        }
+      else
+        {
+          printf ("PASS: crypt_preferred_method: \"%s\" ", pm);
+          printf ("does generate a hash with ");
+          printf ("the intended method.\n");
+        }
+    }
+#else
+  if (pm != NULL)
+    {
+      printf ("FAIL: crypt_preferred_method returned: \"%s\" ", pm);
+      printf ("instead of NULL.\n");
+      retval = 1;
+    }
+  else
+    {
+      printf ("PASS: crypt_preferred_method returned NULL.");
+    }
+#endif
+
+  return retval;
+}


### PR DESCRIPTION
crypt_preferred_method(3) is a convenience function to get the prefix of the preferred hash method.  If a preferred method is available, it is the same as the one also used by the crypt_gensalt functions, if their given prefix parameter is NULL.

If no preferred hash method is supported, the return value of this function is NULL.