### PR TITLE
Fix the actually not happening explicit null dereference found by CovScan.

### DIFF
--- a/lib/alg-yescrypt-opt.c
+++ b/lib/alg-yescrypt-opt.c
@@ -85,6 +85,7 @@
 #include <xmmintrin.h>
 #endif
 
+#include <assert.h>
 #include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -646,6 +647,9 @@ typedef struct {
 static void blockmix(const salsa20_blk_t *restrict Bin,
     salsa20_blk_t *restrict Bout, size_t r, pwxform_ctx_t *restrict ctx)
 {
+	/* ctx MUST NOT be NULL */
+	assert(ctx != NULL);
+
 	uint8_t *S0 = ctx->S0, *S1 = ctx->S1, *S2 = ctx->S2;
 	size_t w = ctx->w;
 	size_t i;
@@ -678,6 +682,9 @@ static uint32_t blockmix_xor(const salsa20_blk_t *Bin1,
     const salsa20_blk_t *restrict Bin2, salsa20_blk_t *Bout,
     size_t r, int Bin2_in_ROM, pwxform_ctx_t *restrict ctx)
 {
+	/* ctx MUST NOT be NULL */
+	assert(ctx != NULL);
+
 	uint8_t *S0 = ctx->S0, *S1 = ctx->S1, *S2 = ctx->S2;
 	size_t w = ctx->w;
 	size_t i;
@@ -739,6 +746,9 @@ static uint32_t blockmix_xor_save(salsa20_blk_t *restrict Bin1out,
     salsa20_blk_t *restrict Bin2,
     size_t r, pwxform_ctx_t *restrict ctx)
 {
+	/* ctx MUST NOT be NULL */
+	assert(ctx != NULL);
+
 	uint8_t *S0 = ctx->S0, *S1 = ctx->S1, *S2 = ctx->S2;
 	size_t w = ctx->w;
 	size_t i;
@@ -1077,7 +1087,6 @@ static void smix(uint8_t *B, size_t r, uint32_t N, uint32_t p, uint32_t t,
 #else
 		salsa20_blk_t *XYp = XY;
 #endif
-		// coverity[assign_zero]
 		pwxform_ctx_t *ctx_i = NULL;
 		if (flags & YESCRYPT_RW) {
 			uint8_t *Si = S + i * Salloc;
@@ -1092,9 +1101,7 @@ static void smix(uint8_t *B, size_t r, uint32_t N, uint32_t p, uint32_t t,
 				HMAC_SHA256_Buf(Bp + (128 * r - 64), 64,
 				    passwd, 32, passwd);
 		}
-		// coverity[var_deref_model : FALSE]
 		smix1(Bp, r, Np, flags, Vp, NROM, VROM, XYp, ctx_i);
-		// coverity[var_deref_model : FALSE]
 		smix2(Bp, r, p2floor(Np), Nloop_rw, flags, Vp,
 		    NROM, VROM, XYp, ctx_i);
 	}


### PR DESCRIPTION
This small change fixes the false positive explicit null dereference found by Coverity Scan in the smix{1,2} functions from alg-yescrypt-opt.c.