### PR TITLE
crypt-nthash: Truncate phrase at a maximum length of 127 bytes.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@ Please send bug reports, questions and suggestions to
 <https://github.com/besser82/libxcrypt/issues>.
 
 Version 4.4.4
+* The NT hashing method no longer truncates passphrases at 128
+  characters; Windows does not do this.  (The Windows login dialog
+  _limits_ interactively entered passphrases to 127 characters.
+  Passphrases set via the low-level API can be longer.)
 
 Version 4.4.3
 * Fix the value of SUNMD5_MAX_ROUNDS.

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,11 @@ Please send bug reports, questions and suggestions to
 <https://github.com/besser82/libxcrypt/issues>.
 
 Version 4.4.4
+* The crypt_* functions will now all fail and set errno to ERANGE if
+  their 'phrase' argument is longer than CRYPT_MAX_PASSPHRASE_SIZE
+  characters (this is currently 512).  Formerly, longer passphrases
+  would either be silently accepted, silently truncated, or the
+  library would crash, depending on the hashing method.
 * The NT hashing method no longer truncates passphrases at 128
   characters; Windows does not do this.  (The Windows login dialog
   _limits_ interactively entered passphrases to 127 characters.

--- a/crypt-nthash.c
+++ b/crypt-nthash.c
@@ -1,5 +1,9 @@
 /*-
+ * Copyright (c) 1998-1999 Whistle Communications, Inc.
+ * Copyright (c) 1998-1999 Archie Cobbs <archie@freebsd.org>
  * Copyright (c) 2003 Michael Bretterklieber
+ * Copyright (c) 2017-2019 Björn Esser <besser82@fedoraproject.org>
+ * Copyright (c) 2017-2019 Zack Weinberg <zackw at panix.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,47 +26,44 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
- *
- * The bogus 'gensalt_nt_rn' function and all modifications to the other
- * parts of this file are
- *
- * Copyright (c) 2017 Björn Esser <besser82@fedoraproject.org>
- * All rights reserved.
- *
- * and is provided under the same licensing terms and conditions as the
- * other parts of this file.
  */
 
 #include "crypt-port.h"
+
+#if INCLUDE_nt
+
 #include "alg-md4.h"
 
 #include <errno.h>
 #include <stdlib.h>
-#include <netinet/in.h>
 
-#if INCLUDE_nt
+#define MD4_HASHLEN        16
+
+typedef struct
+{
+  MD4_CTX ctx;
+  uint8_t unipw[CRYPT_MAX_PASSPHRASE_SIZE * 2];
+  unsigned char hash[MD4_HASHLEN];
+} crypt_nt_internal_t;
+
+static_assert (sizeof (crypt_nt_internal_t) <= ALG_SPECIFIC_SIZE,
+               "ALG_SPECIFIC_SIZE is too small for NTHASH.");
 
 /*
  * NT HASH = md4(str2unicode(phrase))
  */
 
 void
-crypt_nt_rn (const char *phrase, size_t ARG_UNUSED (phr_size),
+crypt_nt_rn (const char *phrase, size_t phr_size,
              const char *setting, size_t ARG_UNUSED (set_size),
              uint8_t *output, size_t out_size,
              void *scratch, size_t scr_size)
 {
-  size_t unipwLen;
-  int i;
-  static const char hexconvtab[] = "0123456789abcdef";
   static const char *magic = "$3$";
-  uint16_t unipw[128];
-  unsigned char hash[16];
-  const char *s;
-  MD4_CTX *ctx = scratch;
+  static const uint8_t *hexconvtab = (const uint8_t*) "0123456789abcdef";
 
-  if ((out_size < 4 + 32) ||
-      (scr_size < sizeof (MD4_CTX)))
+  if ((out_size < strlen (magic) + MD4_HASHLEN * 2 + 1) ||
+      (scr_size < sizeof (crypt_nt_internal_t)))
     {
       errno = ERANGE;
       return;
@@ -74,23 +75,31 @@ crypt_nt_rn (const char *phrase, size_t ARG_UNUSED (phr_size),
       return;
     }
 
-  XCRYPT_SECURE_MEMSET (unipw, sizeof unipw);
-  /* convert to unicode (thanx Archie) */
-  unipwLen = 0;
-  for (s = phrase; unipwLen < sizeof(unipw) / 2 && *s; s++)
-    unipw[unipwLen++] = htons((uint16_t)(*s << 8));
+  crypt_nt_internal_t *intbuf = scratch;
 
-  /* Compute MD4 of Unicode password */
-  MD4_Init (ctx);
-  MD4_Update (ctx, unipw, unipwLen*sizeof(uint16_t));
-  MD4_Final (hash, ctx);
+  /* Convert the input to UCS-2LE, blindly assuming that it was
+     IANA ISO_8859-1:1987 to begin with (i.e. 0x00 .. 0xFF
+     encode U+0000 .. U+FFFF; technically this is a superset
+     of the original ISO 8859.1).  Note that this does not
+     U+0000-terminate intbuf->unipw.  */
+  for (size_t i = 0; i < phr_size; i++)
+    {
+      intbuf->unipw[2*i    ] = (uint8_t)phrase[i];
+      intbuf->unipw[2*i + 1] = 0x00;
+    }
 
+  /* Compute MD4 of Unicode password.  */
+  MD4_Init (&intbuf->ctx);
+  MD4_Update (&intbuf->ctx, intbuf->unipw, phr_size * 2);
+  MD4_Final (intbuf->hash, &intbuf->ctx);
+
+  /* Write the computed hash to the output buffer.  */
   output += XCRYPT_STRCPY_OR_ABORT (output, out_size, magic);
   *output++ = '$';
-  for (i = 0; i < 16; i++)
+  for (size_t i = 0; i < MD4_HASHLEN; i++)
     {
-      *output++ = (uint8_t)hexconvtab[hash[i] >> 4];
-      *output++ = (uint8_t)hexconvtab[hash[i] & 0xf];
+      *output++ = hexconvtab[intbuf->hash[i] >> 4];
+      *output++ = hexconvtab[intbuf->hash[i] & 0xf];
     }
   *output = '\0';
 }

--- a/crypt.3
+++ b/crypt.3
@@ -284,6 +284,12 @@ when they fail.
 .Fa setting
 is invalid, or requests a hashing method that is not supported.
 .It Er ERANGE
+.Fa phrase
+is too long
+(more than
+.Dv CRYPT_MAX_PASSPHRASE_SIZE
+characters; some hashing methods may have lower limits).
+.br
 .Nm crypt_rn
 only:
 .Fa size

--- a/crypt.c
+++ b/crypt.c
@@ -123,6 +123,11 @@ do_crypt (const char *phrase, const char *setting, struct crypt_data *data)
      not valid strings.  */
   size_t phr_size = strlen (phrase);
   size_t set_size = strlen (setting);
+  if (phr_size >= CRYPT_MAX_PASSPHRASE_SIZE)
+    {
+      errno = ERANGE;
+      return;
+    }
   const struct hashfn *h = get_hashfn (setting);
   if (!h)
     {


### PR DESCRIPTION
This change is made to keep consistency with [Microsoft's documentation](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/hh994558(v=ws.10)), which says

> The NT hash is simply a hash. The password is hashed by using the MD4 algorithm and stored... Internally, Windows represents passwords in 256-character UNICODE strings. The logon dialog box is limited to 127 characters. Therefore, the longest password that can be used to log on interactively to a computer running Windows is 127 characters. Programs such as services can use longer passwords, but they must be set programmatically.

Additionally this commit adds serveral optimizations and simplifications to the crypt_nt_rn function.

Closes: #78.