### PR TITLE
gost-yescrypt: Fix alignment problem for GOST 34.11 (Streebog)

### DIFF
--- a/lib/alg-gost3411-2012-core.c
+++ b/lib/alg-gost3411-2012-core.c
@@ -149,10 +149,13 @@ g(uint512_u *h, const uint512_u *N, const unsigned char *m)
 static inline void
 stage2(GOST34112012Context *CTX, const unsigned char *data)
 {
-    g(&(CTX->h), &(CTX->N), data);
+    union uint512_u m;
+
+    memcpy(&m, data, sizeof(m));
+    g(&(CTX->h), &(CTX->N), (const unsigned char *)&m);
 
     add512(&(CTX->N), &buffer512, &(CTX->N));
-    add512(&(CTX->Sigma), (const uint512_u *) data, &(CTX->Sigma));
+    add512(&(CTX->Sigma), &m, &(CTX->Sigma));
 }
 
 static inline void


### PR DESCRIPTION
Some architectures in some circumstances do not allow unaligned
memory access (such as ARM, MIPS, SPARC) triggering SIGBUS. This
patch very crudely fixes this issue.

The issue is found and original fix is proposed by Eric Biggers:

  https://patchwork.kernel.org/patch/10878865/

Being unfixed this would trigger SIGBUS when password buffer is
unaligned. Crash and fix are tested on UltraSparc T5 on GCC Compile
farm.