### PR TITLE
Fix compilation error with older versions of glibc.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@ Please send bug reports, questions and suggestions to
 <https://github.com/besser82/libxcrypt/issues>.
 
 Version 4.4.17
+* Fix compilation error in 'alignas (type)' with older versions
+  of glibc and/or gcc (issue #107).
 
 Version 4.4.16
 * Add support for the e2k architecture.

--- a/lib/crypt.c
+++ b/lib/crypt.c
@@ -32,7 +32,7 @@
    struct, since the first field must always have offset 0.  */
 struct crypt_internal
 {
-  char alignas (max_align_t) alg_specific[ALG_SPECIFIC_SIZE];
+  char alignas (alignof (max_align_t)) alg_specific[ALG_SPECIFIC_SIZE];
 };
 
 static_assert(sizeof (struct crypt_internal) + alignof (struct crypt_internal)


### PR DESCRIPTION
`alignas (type)` is equivalent to `alignas (alignof (type))`, but seems to be more compatible with older compilers and/or older implementations of libc.

Fixes #107