### PR TITLE
Fix build on (Free)BSD.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@ Please send bug reports, questions and suggestions to
 <https://github.com/besser82/libxcrypt/issues>.
 
 Version 4.4.18
+* Fix compilation errors on (Free)BSD (issue #110).
 
 Version 4.4.17
 * Fix compilation error in 'alignas (type)' with older versions

--- a/lib/crypt-port.h
+++ b/lib/crypt-port.h
@@ -50,6 +50,23 @@
 #include <sys/param.h>
 #endif
 
+/* The prototypes of the crypt() function and struct crypt_data possibly
+   defined in <unistd.h> need to be renamed as they might be incompatible
+   with our declaration.
+   Defining these macros *AFTER* <crypt-symbol-vers.h>, which also defines
+   the same macros for symbol-versioning purposes, was included, would lead
+   to a clashing redefinition of these macros, and thus cause our internal
+   symbol-versioning would not work properly anymore.  */
+#ifdef HAVE_UNISTD_H
+#define crypt unistd_crypt_is_incompatible
+#define crypt_r unistd_crypt_r_is_incompatible
+#define crypt_data unistd_crypt_data_is_incompatible
+#include <unistd.h>
+#undef crypt
+#undef crypt_r
+#undef crypt_data
+#endif
+
 #ifndef HAVE_SYS_CDEFS_THROW
 #define __THROW /* nothing */
 #endif

--- a/lib/randombytes.c
+++ b/lib/randombytes.c
@@ -31,9 +31,6 @@
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
 
 /* If we have O_CLOEXEC, we use it, but if we don't, we don't worry
    about it.  */

--- a/test/badsalt.c
+++ b/test/badsalt.c
@@ -22,7 +22,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/mman.h>
-#include <unistd.h>
 
 static const char phrase[] = "values of β will give rise to dom!";
 

--- a/test/crypt-badargs.c
+++ b/test/crypt-badargs.c
@@ -78,7 +78,7 @@ static const char *settings[] =
 };
 
 /* In some of the tests below, a segmentation fault is the expected result.  */
-static jmp_buf env;
+static sigjmp_buf env;
 static void
 segv_handler (int sig)
 {

--- a/test/crypt-badargs.c
+++ b/test/crypt-badargs.c
@@ -15,7 +15,6 @@
 #include <string.h>
 #include <signal.h>
 #include <sys/mman.h>
-#include <unistd.h>
 
 /* The behavior tested below should be consistent for all hashing
    methods.  */

--- a/test/getrandom-fallbacks.c
+++ b/test/getrandom-fallbacks.c
@@ -23,9 +23,6 @@
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
 
 /* If arc4random_buf is available, all of the fallback logic is compiled
    out and this test is unnecessary.  If ld --wrap is not available this

--- a/test/getrandom-interface.c
+++ b/test/getrandom-interface.c
@@ -125,7 +125,7 @@ test_fault (char *page, size_t pagesize)
 }
 
 /* In one of the tests above, a segmentation fault is the expected result.  */
-static jmp_buf env;
+static sigjmp_buf env;
 static void
 segv_handler (int sig)
 {

--- a/test/getrandom-interface.c
+++ b/test/getrandom-interface.c
@@ -15,7 +15,6 @@
 #include <string.h>
 #include <signal.h>
 #include <sys/mman.h>
-#include <unistd.h>
 
 static bool error_occurred;
 


### PR DESCRIPTION
#### Include <unistd.h> without declaring crypt prototypes.
The prototypes of the crypt{,_r}() function and struct crypt_data possibly defined in <unistd.h> need to be renamed as they might be incompatible with our declarations.
We achieve this by defining macros *BEFORE* including <unistd.h> at the top of <crypt-port.h> and undefining them directly afterwards.

Defining these macros *AFTER* <crypt-symbol-vers.h>, which also defines the same macros for symbol-versioning purposes, was included, would lead to a clashing redefinition of this macro, and thus cause our internal symbol-versioning would not work properly anymore.

Also drop any direct inclusion of <unistd.h> in several source files.

Fixes #110.

***

#### Use sigjmp_buf instead of jmp_buf for the sigjmp() function.
This change is made to be conformant with the IEEE Std 1003.1-2001, also known as POSIX 2001, which explicitly requires the function to be called with struct sigjmp_buf as the first parameter.

While glibc defines both data-structures to be identical, other libc implementations may define them individually, and thus, from the POV of the C compiler to be different and/or incompatible types.