### PR TITLE
lib/alg-gost3411-core.c: fix conversion error seen by sensitive compilers

### DIFF
--- a/lib/alg-gost3411-2012-core.c
+++ b/lib/alg-gost3411-2012-core.c
@@ -92,7 +92,7 @@ add512(const uint512_u *x, const uint512_u *y, uint512_u *r)
     for (i = 0; i < 64; i++)
     {
         buf = xp[i] + yp[i] + (buf >> 8);
-        rp[i] = (unsigned char) buf & 0xFF;
+        rp[i] = (unsigned char) (buf & 0xFF);
     }
 #endif
 }


### PR DESCRIPTION
Some compilers might be sensitive and raise an Warning/error on this line.

Signed-off-by: Guillaume W. Bres <guillaume.bressaix@gmail.com>