### PR TITLE
Indicate weak hashes by crypt_checksalt().

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@ Please send bug reports, questions and suggestions to
 <https://github.com/besser82/libxcrypt/issues>.
 
 Version 4.4.21
+* The crypt_checksalt() function will now return the value
+  'CRYPT_SALT_METHOD_LEGACY' in case the setting, that is passed
+  to be checked, uses a hashing method, which is considered to be
+  too weak for use with new passphrases.
 
 Version 4.4.20
 * Fix build when the CFLAGS variable, that is passed into the

--- a/build-aux/BuildCommon.pm
+++ b/build-aux/BuildCommon.pm
@@ -293,14 +293,16 @@ sub which {
 #
 
 use Class::Struct HashSpec => [
-    name    => '$',
-    prefix  => '$',
-    nrbytes => '$',
+    name      => '$',
+    prefix    => '$',
+    nrbytes   => '$',
+    is_strong => '$',
 ];
 use Class::Struct HashesConfData => [
     hashes             => '*%',
     groups             => '*%',
     max_namelen        => '$',
+    max_nrbyteslen     => '$',
     max_prefixlen      => '$',
     default_candidates => '*@',
 ];
@@ -351,8 +353,9 @@ sub parse_hashes_conf {
     my %line_of;
     my %hashes;
     my %groups;
-    my $max_namelen   = 0;
-    my $max_prefixlen = 0;
+    my $max_namelen    = 0;
+    my $max_nrbyteslen = 0;
+    my $max_prefixlen  = 0;
     my @default_candidates;
     local $_;
     while (<$fh>) {
@@ -397,6 +400,10 @@ sub parse_hashes_conf {
             $nrbytes = 1;
         }
 
+        if ($max_nrbyteslen < length $nrbytes) {
+            $max_nrbyteslen = length $nrbytes;
+        }
+
         $flags = q{} if $flags eq ':';
         for (split /,/, $flags) {
             if (!exists $VALID_FLAGS{$_}) {
@@ -417,9 +424,10 @@ sub parse_hashes_conf {
         next if $error;
 
         my $entry = HashSpec->new(
-            name    => $name,
-            prefix  => $h_prefix,
-            nrbytes => $nrbytes,
+            name      => $name,
+            prefix    => $h_prefix,
+            nrbytes   => $nrbytes,
+            is_strong => $is_strong,
         );
         $hashes{$name} = $entry;
         for my $g (@grps) {
@@ -458,6 +466,7 @@ sub parse_hashes_conf {
         hashes             => \%hashes,
         groups             => \%groups,
         max_namelen        => $max_namelen,
+        max_nrbyteslen     => $max_nrbyteslen,
         max_prefixlen      => $max_prefixlen,
         default_candidates => \@default_candidates,
     );

--- a/build-aux/gen-crypt-hashes-h
+++ b/build-aux/gen-crypt-hashes-h
@@ -87,15 +87,16 @@ EOT
     } @enabled_hashes;
 
     for my $e (@table_hashes) {
-        my $name_rn  = $e->name . '_rn,';
-        my $q_prefix = '"' . $e->prefix . '",';
-        printf "  { %-*s %d, crypt_%-*s gensalt_%-*s %s }, \\\n",
-            $hconf->max_prefixlen + 2, $q_prefix, length($e->prefix),
-            $hconf->max_namelen + 4,   $name_rn,
-            $hconf->max_namelen + 4,   $name_rn,
-            $e->nrbytes;
+        my $name_rn     = $e->name . '_rn,';
+        my $q_prefix    = '"' . $e->prefix . '",';
+        my $str_nrbytes = $e->nrbytes . ',';
+        printf "  { %-*s %d, crypt_%-*s gensalt_%-*s %-*s %s}, \\\n",
+            $hconf->max_prefixlen + 3,  $q_prefix, length($e->prefix),
+            $hconf->max_namelen + 4,    $name_rn,
+            $hconf->max_namelen + 4,    $name_rn,
+            $hconf->max_nrbyteslen + 1, $str_nrbytes, $e->is_strong;
     }
-    print "  { 0, 0, 0, 0, 0 }\n";
+    print "  { 0, 0, 0, 0, 0, 0 }\n";
 
     # The default_candidates array is in decreasing order of strength;
     # select the first one that's enabled, if any.

--- a/doc/crypt_checksalt.3
+++ b/doc/crypt_checksalt.3
@@ -51,7 +51,7 @@ specifies a hashing method that is no longer allowed to be used at all;
 will fail if passed this
 .Ar setting .
 Manual intervention will be required to reactivate the user's account.
-.It Dv CRYPT_SALT_METHOD_LEGACY (Not implemented, yet)
+.It Dv CRYPT_SALT_METHOD_LEGACY
 .Ar setting
 specifies a hashing method that is no longer considered strong enough
 for use with new passphrases.

--- a/lib/crypt.c
+++ b/lib/crypt.c
@@ -68,6 +68,7 @@ struct hashfn
   /* The type of this field is unsigned char to ensure that it cannot
      be set larger than the size of an internal buffer in crypt_gensalt_rn.  */
   unsigned char nrbytes;
+  unsigned char is_strong;
 };
 
 static const struct hashfn hash_algorithms[] =

--- a/lib/crypt.c
+++ b/lib/crypt.c
@@ -321,7 +321,12 @@ crypt_checksalt (const char *setting)
   const struct hashfn *h = get_hashfn (setting);
 
   if (h)
-    retval = CRYPT_SALT_OK;
+    {
+      retval = CRYPT_SALT_OK;
+
+      if (h->is_strong == 0)
+        retval = CRYPT_SALT_METHOD_LEGACY;
+    }
 
   return retval;
 }

--- a/lib/crypt.h.in
+++ b/lib/crypt.h.in
@@ -211,7 +211,7 @@ extern int crypt_checksalt (const char *__setting);
 #define CRYPT_SALT_OK              0
 #define CRYPT_SALT_INVALID         1
 #define CRYPT_SALT_METHOD_DISABLED 2  /* NOT implemented, yet. */
-#define CRYPT_SALT_METHOD_LEGACY   3  /* NOT implemented, yet. */
+#define CRYPT_SALT_METHOD_LEGACY   3
 #define CRYPT_SALT_TOO_CHEAP       4  /* NOT implemented, yet. */
 
 /* Convenience function to get the prefix of the preferred hash method,

--- a/test/checksalt.c
+++ b/test/checksalt.c
@@ -30,83 +30,83 @@ struct testcase
 static const struct testcase testcases[] =
 {
 #if INCLUDE_descrypt || INCLUDE_bigcrypt
-  { "",      CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
-  { "..",    CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
-  { "MN",    CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
+  { "",      CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY },
+  { "..",    CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY },
+  { "MN",    CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY },
 #else
-  { "",      CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
-  { "..",    CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
-  { "MN",    CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "",      CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
+  { "..",    CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
+  { "MN",    CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #endif
 #if INCLUDE_bsdicrypt
-  { "_",     CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
+  { "_",     CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY },
 #else
-  { "_",     CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "_",     CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #endif
 #if INCLUDE_md5crypt
-  { "$1$",   CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
+  { "$1$",   CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY },
 #else
-  { "$1$",   CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "$1$",   CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #endif
 #if INCLUDE_nt
-  { "$3$",   CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
+  { "$3$",   CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY },
 #else
-  { "$3$",   CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "$3$",   CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #endif
 #if INCLUDE_sunmd5
-  { "$md5",  CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
+  { "$md5",  CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY },
 #else
-  { "$md5",  CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "$md5",  CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #endif
 #if INCLUDE_sha1crypt
-  { "$sha1", CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
+  { "$sha1", CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY },
 #else
-  { "$sha1", CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "$sha1", CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #endif
 #if INCLUDE_sha256crypt
-  { "$5$",   CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
+  { "$5$",   CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_METHOD_LEGACY },
 #else
-  { "$5$",   CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "$5$",   CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #endif
 #if INCLUDE_sha512crypt
-  { "$6$",   CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
+  { "$6$",   CRYPT_SALT_OK,            CRYPT_SALT_OK,            CRYPT_SALT_OK            },
 #else
-  { "$6$",   CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "$6$",   CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #endif
 #if INCLUDE_bcrypt
-  { "$2b$",  CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
+  { "$2b$",  CRYPT_SALT_OK,            CRYPT_SALT_OK,            CRYPT_SALT_OK            },
 #else
-  { "$2b$",  CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "$2b$",  CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #endif
 #if INCLUDE_bcrypt_a
-  { "$2a$",  CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
+  { "$2a$",  CRYPT_SALT_OK,            CRYPT_SALT_OK,            CRYPT_SALT_OK            },
 #else
-  { "$2a$",  CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "$2a$",  CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #endif
 #if INCLUDE_bcrypt_x
-  { "$2x$",  CRYPT_SALT_OK,      CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "$2x$",  CRYPT_SALT_METHOD_LEGACY, CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #else
-  { "$2x$",  CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "$2x$",  CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #endif
 #if INCLUDE_bcrypt_y
-  { "$2y$",  CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
+  { "$2y$",  CRYPT_SALT_OK,            CRYPT_SALT_OK,            CRYPT_SALT_OK            },
 #else
-  { "$2y$",  CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "$2y$",  CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #endif
 #if INCLUDE_yescrypt
-  { "$y$",   CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
+  { "$y$",   CRYPT_SALT_OK,            CRYPT_SALT_OK,            CRYPT_SALT_OK            },
 #else
-  { "$y$",   CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "$y$",   CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #endif
 #if INCLUDE_scrypt
-  { "$7$",   CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
+  { "$7$",   CRYPT_SALT_OK,            CRYPT_SALT_OK,            CRYPT_SALT_OK            },
 #else
-  { "$7$",   CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "$7$",   CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #endif
 #if INCLUDE_gost_yescrypt
-  { "$gy$",  CRYPT_SALT_OK,      CRYPT_SALT_OK,      CRYPT_SALT_OK      },
+  { "$gy$",  CRYPT_SALT_OK,            CRYPT_SALT_OK,            CRYPT_SALT_OK            },
 #else
-  { "$gy$",  CRYPT_SALT_INVALID, CRYPT_SALT_INVALID, CRYPT_SALT_INVALID },
+  { "$gy$",  CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID,       CRYPT_SALT_INVALID       },
 #endif
 
   /* All of these are invalid. */


### PR DESCRIPTION
The hashes.conf file used to define the hashing methods supported by libxcrypt defines a group of STRONG hashing methods.  Those methods, that are not members of this group, are considered to be too weak for still being used for new passphrases.

The crypt_checksalt() function now returns `CRYPT_SALT_METHOD_LEGACY` for such settings.
