### PR TITLE
Update codecov.yml to codecov/codecov-action@v2.

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -54,10 +54,15 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-      # note: the 'llvm' package is needed for llvm-cov (only when using clang)
+
     - name: Install packages
-      if: ${{ matrix.compiler == 'clang' }}
-      run: sudo apt-get install clang llvm
+      run: |
+        packages="lcov"
+        if [ "$CC" = clang ]; then
+          # need 'llvm' for llvm-cov, as well as clang
+          packages="$packages clang llvm"
+        fi
+        sudo apt-get install $packages
     - name: Versions of build tools
       run: ./build-aux/ci-log-dependency-versions
     - name: Bootstrap
@@ -68,12 +73,11 @@ jobs:
       run: make
     - name: Test
       run: make check || (cat test-suite.log; exit 1)
-    - name: Codecov
-      uses: codecov/codecov-action@v1
+    - name: Summarize coverage data
+      run: ./build-aux/summarize-coverage coverage.info
+    - name: Upload coverage data to Codecov
+      uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true
-        gcov_executable: ./build-aux/gcov-wrapper
-        gcov_path_exclude: "./test/*"
-        gcov_root_dir: .
-        token: ${{ secrets.CODECOV_TOKEN }}
-        verbose: false
+        verbose: true
+        files: coverage.info

--- a/build-aux/ci-log-dependency-versions
+++ b/build-aux/ci-log-dependency-versions
@@ -13,7 +13,10 @@ for tool in \
     "${CPANM-cpanm}" \
     "${PERLCRITIC-perlcritic}" \
     "${PERLTIDY-perltidy}" \
-    "${PYTHON-python3}"
+    "${PYTHON-python3}" \
+    "${GCOV-gcov}" \
+    "${LCOV-lcov}" \
+    "${LLVM_COV-llvm-cov}"
 do
     # $tool might include mandatory command-line arguments.
     # Interpret it the same way Make would.
@@ -32,7 +35,7 @@ try:
   print("passlib is " + os.path.dirname(passlib.__file__))
   print("passlib: version " + passlib.__version__)
 except ModuleNotFoundError:
-  print("passlib is not installed")
+  print("passlib is not installed\n")
 '
             ;;
     esac

--- a/build-aux/clang-gcov-wrapper
+++ b/build-aux/clang-gcov-wrapper
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec llvm-cov gcov "$@"

--- a/build-aux/gcov-wrapper
+++ b/build-aux/gcov-wrapper
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-if [ "x$CC" = "xclang" ]; then
-  exec llvm-cov gcov "$@"
-fi
-
-if [ "x$CC" = "xgcc" ]; then
-  exec gcov "$@"
-fi

--- a/build-aux/summarize-coverage
+++ b/build-aux/summarize-coverage
@@ -1,0 +1,24 @@
+#! /bin/sh
+set -e
+
+case "$CC" in
+    (*clang*)
+        GCOV=$(pwd)/build-aux/clang-gcov-wrapper ;;
+    (*)
+        GCOV=gcov ;;
+esac
+
+unpruned=$(mktemp --tmpdir all-coverage.XXXXXXXXXX.info)
+trap 'rm -f "'"$unpruned"'"' 0
+
+set -x
+# Merge all of the gcov output into one overview file using lcov,
+# then prune data for the tests themselves, and for system libraries.
+
+lcov --gcov-tool "$GCOV" --rc lcov_branch_coverage=1 \
+     --directory . --output-file "$unpruned" \
+     --capture
+
+lcov --gcov-tool "$GCOV" --rc lcov_branch_coverage=1 \
+     --directory . --output-file "$1" \
+     --remove "$unpruned" '/usr/*' '*test*'


### PR DESCRIPTION
codecov-action@v1 is deprecated due to its inextricable coupling with
Codecov’s shell-script uploader, which is also deprecated, due to its
being an unmaintainable pile of shell script.  See
https://github.com/codecov/codecov-action/blob/635d4e88ad8c1f75b56277efd9ec186c3359727f/README.md#%EF%B8%8F--deprecration-of-v1 [sic]
and https://about.codecov.io/blog/introducing-codecovs-new-uploader/
for gory details.

The new uploader does not support the ‘gcov_executable‘ and
‘gcov_path_exclude‘ parameters yet, so for the time being we go back
to preprocessing the coverage data with lcov (as we were doing on
Travis).