### PR TITLE
Provide an opportunity to build libxcrypt without symvers

### DIFF
--- a/build-aux/scripts/gen-crypt-symbol-vers-h
+++ b/build-aux/scripts/gen-crypt-symbol-vers-h
@@ -60,6 +60,26 @@ EOT
             $sym->included && !$sym->compat_only;
     }
 
+    if (defined $ENV{"DO_NOT_GENERATE_SYMVERS"}) {
+        print <<'EOT';
+
+#endif
+
+/* We are building this library with no symbol versioning
+   enabled, so let's define all macros for SYMVER_ to do
+   nothing. */
+EOT
+        for my $sym (@{$symvers->symbols}) {
+            my $name = $sym->name;
+            print "#define SYMVER_$name symver_nop()\n";
+        }
+        print <<'EOT';
+#endif
+EOT
+        close STDOUT or die "write error: $!\n";
+        return;
+    }
+
     print <<'EOT';
 
 #endif


### PR DESCRIPTION
This tries to (partially) address #142 .  This PR introduces a condition inside the `gen-crypt-symbol-vers-h` helper script, which is used to generate a header file with versioning info.  If the `DO_NOT_GENERATE_SYMVERS` environment variable is present, then the script won't produce versioning info.

I think maintainers have a better idea on how to integrate this into the autotools build system than I am.  Ideally, when somebody passes `--disable-symvers` to configure the aforementioned environment variable should be set before calling the script.