### PR TITLE
Fixes for issue 145

### DIFF
--- a/doc/crypt.5
+++ b/doc/crypt.5
@@ -170,7 +170,7 @@ and does not show the division into prefix, options, salt, and hash.
 yescrypt is a scalable passphrase hashing scheme designed by Solar Designer,
 which is based on Colin Percival's scrypt.
 Recommended for new hashes.
-.hash "$y$" "\e$y\e$[./A-Za-z0-9]+\e$[./A-Za-z0-9]{,86}\e$[./A-Za-z0-9]{43}" unlimited 8 256 256 "up to 512" "1 to 11 (logarithmic)"
+.hash "$y$" "\e$y\e$[./A-Za-z0-9]+\e$[./A-Za-z0-9]{,86}\e$[./A-Za-z0-9]{43}" unlimited 8 256 256 "up to 512 (128+ recommended)" "1 to 11 (logarithmic)"
 .Ss gost-yescrypt
 gost-yescrypt uses the output from the yescrypt hashing method in place of a
 hmac message.  Thus, the yescrypt crypto properties are superseded by the
@@ -181,14 +181,14 @@ algorithms.
 The GOST R 34.11-2012 (Streebog) hash function has been published by the IETF
 as RFC 6986.
 Recommended for new hashes.
-.hash "$gy$" "\e$gy\e$[./A-Za-z0-9]+\e$[./A-Za-z0-9]{,86}\e$[./A-Za-z0-9]{43}" unlimited 8 256 256 "up to 512" "1 to 11 (logarithmic)"
+.hash "$gy$" "\e$gy\e$[./A-Za-z0-9]+\e$[./A-Za-z0-9]{,86}\e$[./A-Za-z0-9]{43}" unlimited 8 256 256 "up to 512 (128+ recommended)" "1 to 11 (logarithmic)"
 .Ss scrypt
 scrypt is a password-based key derivation function created by Colin Percival,
 originally for the Tarsnap online backup service.
 The algorithm was specifically designed to make it costly to perform
 large-scale custom hardware attacks by requiring large amounts of memory.
 In 2016, the scrypt algorithm was published by IETF as RFC 7914.
-.hash "$7$" "\e$7\e$[./A-Za-z0-9]{11,97}\e$[./A-Za-z0-9]{43}" unlimited 8 256 256 "up to 512" "6 to 11 (logarithmic)"
+.hash "$7$" "\e$7\e$[./A-Za-z0-9]{11,97}\e$[./A-Za-z0-9]{43}" unlimited 8 256 256 "up to 512 (128+ recommended)" "6 to 11 (logarithmic)"
 .Ss bcrypt
 A hash based on the Blowfish block cipher,
 modified to have an extra-expensive key schedule.

--- a/lib/crypt-gost-yescrypt.c
+++ b/lib/crypt-gost-yescrypt.c
@@ -58,6 +58,10 @@ gensalt_gost_yescrypt_rn (unsigned long count,
                           const uint8_t *rbytes, size_t nrbytes,
                           uint8_t *output, size_t o_size)
 {
+  /* Up to 512 bits (64 bytes) of entropy for computing the salt portion
+     of the MCF-setting are supported.  */
+  nrbytes = (nrbytes > 64 ? 64 : nrbytes);
+
   if (o_size < 4 + 8 * 6 + BASE64_LEN (nrbytes) + 1 ||
       CRYPT_GENSALT_OUTPUT_SIZE < 4 + 8 * 6 + BASE64_LEN (nrbytes) + 1)
     {

--- a/lib/crypt-scrypt.c
+++ b/lib/crypt-scrypt.c
@@ -165,6 +165,10 @@ gensalt_scrypt_rn (unsigned long count,
                    const uint8_t *rbytes, size_t nrbytes,
                    uint8_t *output, size_t o_size)
 {
+  /* Up to 512 bits (64 bytes) of entropy for computing the salt portion
+     of the MCF-setting are supported.  */
+  nrbytes = (nrbytes > 64 ? 64 : nrbytes);
+
   if (o_size < 3 + 1 + 5 * 2 + BASE64_LEN (nrbytes) + 1 ||
       CRYPT_GENSALT_OUTPUT_SIZE < 3 + 1 + 5 * 2 + BASE64_LEN (nrbytes) + 1)
     {

--- a/lib/crypt-yescrypt.c
+++ b/lib/crypt-yescrypt.c
@@ -106,6 +106,10 @@ gensalt_yescrypt_rn (unsigned long count,
                      const uint8_t *rbytes, size_t nrbytes,
                      uint8_t *output, size_t o_size)
 {
+  /* Up to 512 bits (64 bytes) of entropy for computing the salt portion
+     of the MCF-setting are supported.  */
+  nrbytes = (nrbytes > 64 ? 64 : nrbytes);
+
   if (o_size < 3 + 8 * 6 + 1 + BASE64_LEN (nrbytes) + 1 ||
       CRYPT_GENSALT_OUTPUT_SIZE < 3 + 8 * 6 + 1 + BASE64_LEN (nrbytes) + 1)
     {


### PR DESCRIPTION
doc/crypt.5: Document the recommended amount of salt-bits for `yescrypt`.

Also document the same value as the recommended amount for `gost-yescrypt` and `scrypt`.

***

lib: Silently truncate rbytes after a maximum of 512 bits for `yescrypt`.

Likewise for `gost-yescrypt` and `scrypt`, as those hashing methods share the same codebase.