### PR TITLE
Generate a sufficiently random stop-commands token

### DIFF
--- a/build-aux/ci/ci-log-logfiles
+++ b/build-aux/ci/ci-log-logfiles
@@ -1,12 +1,18 @@
 #! /bin/sh
 
+generate_secure_token() {
+    echo head --bytes 64 /dev/urandom | sha512sum --binary | cut --fields 1 --delimiter ' '
+}
+
 dump_log () {
     if [ -s "$1" ]; then
+        local stop_command_token="$(generate_secure_token)"
         echo "::group::$1"
-        echo '::stop-commands::resume-50YEO1zJ8HSXH4Zy'
+        echo "::stop-commands::$stop_command_token"
         cat "$1"
-        echo '::resume-50YEO1zJ8HSXH4Zy::'
+        echo "::$stop_command_token::"
         echo '::endgroup::'
+        unset stop_command_token
     fi
 }
 

--- a/build-aux/ci/ci-log-logfiles
+++ b/build-aux/ci/ci-log-logfiles
@@ -6,7 +6,7 @@ generate_secure_token() {
 
 dump_log () {
     if [ -s "$1" ]; then
-        local stop_command_token="$(generate_secure_token)"
+        stop_command_token="$(generate_secure_token)"
         echo "::group::$1"
         echo "::stop-commands::$stop_command_token"
         cat "$1"


### PR DESCRIPTION
The token in ::stop-commands::{token} GA workflow command has to be a cryptographically random and secure string. Definitely not a hardcoded string literal. See the docs for details: https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#stopping-and-starting-workflow-commands

I've enabled my local GitHub Actions to see if I can see the changes in action, however, only some of the Actions ran and the call to `ci-log-logfiles` has not been triggered.