### PR TITLE
Handle properly looping over filenames with whitespace

### DIFF
--- a/build-aux/ci/ci-log-logfiles
+++ b/build-aux/ci/ci-log-logfiles
@@ -11,6 +11,6 @@ dump_log () {
 }
 
 dump_log config.log
-for ts in $(find . -name 'test-suite*.log' -printf '%P\n'); do
+find . -name 'test-suite*.log' -printf '%P\n' | while read -r ts; do
     dump_log "$ts"
 done


### PR DESCRIPTION
Using `-exec` would be another option, maybe slightly simpler.