### PR TITLE
libcrypt.minver: Mark LoongArch as free of legacy ABIs

### DIFF
--- a/lib/libcrypt.minver
+++ b/lib/libcrypt.minver
@@ -60,6 +60,7 @@ GLIBC_2.3    kfreebsd.*gnu   i[3-9]86
 ERROR        kfreebsd.*gnu   .
 
 # Linux with GNU libc
+XCRYPT_2.0   linux.*gnu      loongarch
 GLIBC_2.35   linux.*gnu      or1k
 GLIBC_2.33   linux.*gnu      riscv32
 GLIBC_2.32   linux.*gnu      arc


### PR DESCRIPTION
This architecture is new, so there is no existing binaries to consider
legacy compatibility for.