### PR TITLE
restore ucontext api functionality check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,6 @@ fi
 AC_CHECK_HEADERS_ONCE([
   fcntl.h
   stdbool.h
-  ucontext.h
   sys/cdefs.h
   sys/random.h
   sys/syscall.h
@@ -289,6 +288,39 @@ else
 fi
 AC_SUBST([PYTHON])
 AM_CONDITIONAL([ENABLE_KA_TABLE_GEN], [test x"$PYTHON" != "xfalse"])
+
+# The ucontext.h functions that we use were withdrawn from
+# POSIX.1-2008, so the existence of the header does not prove
+# we can use the functions.
+AS_IF([test $ac_cv_header_ucontext_h = yes],
+  [AC_CACHE_CHECK([whether all ucontext.h functions are available],
+     [ac_cv_header_ucontext_h_fns_available],
+     [AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+// This code isn't intended to make sense; it just validates the
+// type signature of all four context functions, and avoids tripping
+// any of the many warnings we may have active.
+#include <ucontext.h>
+static int x;
+static void fn1(void) {}
+static void fn2(int a, int b) { x = a - b; }
+]], [[
+  ucontext_t uc1, uc2;
+  if (getcontext(&uc1)) return 1;
+  if (setcontext(&uc1)) return 1;
+  makecontext(&uc1, fn1, 0);
+  makecontext(&uc2, fn2, 2, 1, 1);
+  if (swapcontext(&uc1, &uc2)) return 1;
+  return x;
+]])],
+        [ac_cv_header_ucontext_h_fns_available=yes],
+        [ac_cv_header_ucontext_h_fns_available=no])])],
+  [ac_cv_header_ucontext_h_fns_available=no])
+
+if test $ac_cv_header_ucontext_h_fns_available = yes; then
+  AC_DEFINE([USE_SWAPCONTEXT], 1,
+    [Define to 1 if getcontext, setcontext, makecontext, and swapcontext are
+     available from ucontext.h without deprecation warnings.])
+fi
 
 # Configure options.
 AC_ARG_ENABLE([failure-tokens],

--- a/test/explicit-bzero.c
+++ b/test/explicit-bzero.c
@@ -40,7 +40,7 @@
 
 #include "crypt-port.h"
 
-#ifndef HAVE_UCONTEXT_H
+#ifndef USE_SWAPCONTEXT
 /* We can't do this test if we don't have the ucontext API.  */
 int main(void)
 {


### PR DESCRIPTION
In c3f01c72b303cbbb0cc8983120677edee2f3fa4b the use of the ucontext api in the main program was removed, and with it the configure check for it. However, the ucontext api is still used in the "explicit_bzero" test and this has the same problem as described in the comment:

> The ucontext.h functions that we use were withdrawn from
> POSIX.1-2008, so the existence of the header does not prove
> we can use the functions.

Thus, restore the full configure check and use it instead of the header check for the explicit_bzero test.

See https://bugs.gentoo.org/838172