### PR TITLE
configure: Restore the functionality of the '--disable-symvers' switch.

### DIFF
--- a/.github/workflows/config-matrix.yml
+++ b/.github/workflows/config-matrix.yml
@@ -37,6 +37,7 @@ jobs:
         - "--enable-obsolete-api --enable-hashes=all --enable-obsolete-api-enosys"
         - "--enable-obsolete-api --enable-hashes=all --disable-failure-tokens"
         - "--enable-obsolete-api --enable-hashes=all --enable-obsolete-api-enosys --disable-failure-tokens"
+        - "--enable-obsolete-api --enable-hashes=all --disable-symvers"
         - "--enable-obsolete-api --enable-hashes=glibc"
         - "--enable-obsolete-api=glibc --enable-hashes=strong,glibc"
 
@@ -47,6 +48,7 @@ jobs:
         - "--disable-obsolete-api --enable-hashes=all --disable-shared"
         - "--disable-obsolete-api --enable-hashes=all --disable-static"
         - "--disable-obsolete-api --enable-hashes=all --disable-failure-tokens"
+        - "--disable-obsolete-api --enable-hashes=all --disable-symvers"
         - "--disable-obsolete-api --enable-hashes=strong"
 
         # Configurations with only one hash enabled.  These exist to

--- a/Makefile.am
+++ b/Makefile.am
@@ -156,6 +156,9 @@ libcrypt_la_LDFLAGS = -version-info $(libcrypt_la_VERSION)
 
 if HAVE_VSCRIPT
 libcrypt_la_LDFLAGS += $(VSCRIPT_LDFLAGS),$(builddir)/libcrypt.map
+APPLY_SYMVERS = yes
+else
+APPLY_SYMVERS = no
 endif
 
 libcrypt_la_LDFLAGS += $(UNDEF_FLAG) $(TEXT_RELOC_FLAG) $(AM_LDFLAGS)
@@ -224,6 +227,7 @@ crypt-symbol-vers.h.stamp: \
 		lib/libcrypt.map.in Makefile
 	$(AM_V_GENS)LC_ALL=C $(PERL) \
 	  $(SCRIPTS_AUX)/gen-crypt-symbol-vers-h \
+	  $(APPLY_SYMVERS) \
 	  SYMVER_MIN=$(SYMVER_MIN) \
 	  SYMVER_FLOOR=$(SYMVER_FLOOR) \
 	  COMPAT_ABI=$(COMPAT_ABI) \

--- a/build-aux/scripts/gen-crypt-symbol-vers-h
+++ b/build-aux/scripts/gen-crypt-symbol-vers-h
@@ -30,7 +30,7 @@ use BuildCommon qw(
 );
 
 sub output {
-    my ($symvers) = @_;
+    my ($apply_symvers, $symvers) = @_;
     my $basemap = $symvers->basemap;
     print "/* Generated from $basemap by ${FindBin::Script}.  "
         . "DO NOT EDIT.  */\n";
@@ -58,6 +58,26 @@ EOT
         printf "#define INCLUDE_%-*s %d\n",
             $symvers->max_symlen, $sym->name,
             $sym->included && !$sym->compat_only;
+    }
+
+    if ($apply_symvers =~ m/no/) {
+        print <<'EOT';
+
+#endif
+
+/* We are building this library with no symbol versioning
+   enabled, so let's define all macros for SYMVER_ to do
+   nothing. */
+EOT
+        for my $sym (@{$symvers->symbols}) {
+            my $name = $sym->name;
+            print "#define SYMVER_$name symver_nop()\n";
+        }
+        print <<'EOT';
+#endif
+EOT
+        close STDOUT or die "write error: $!\n";
+        return;
     }
 
     print <<'EOT';
@@ -122,7 +142,7 @@ EOT
 # Main
 #
 exit 0 if eval {
-    output(parse_version_map_in(@ARGV));
+    output($ARGV[0], parse_version_map_in(@ARGV[1 .. 4]));
     1;
 };
 

--- a/configure.ac
+++ b/configure.ac
@@ -513,6 +513,14 @@ fi
 AC_SUBST([SYMVER_FLOOR])
 AC_SUBST([SYMVER_MIN])
 
+# If symbol versioning is disabled for any reason, we should not rely on
+# versioned symbols in the testsuite.
+have_symver=0
+if test x$ax_check_vscript_flag != x; then have_symver=1; fi
+
+AC_DEFINE_UNQUOTED([HAVE_SYMVER], [$have_symver],
+  [Define as 1 if symbol versioning is enabled and applied.])
+
 # If we are not building the obsolete APIs then we shouldn't install
 # xcrypt.h or the compatibility symlinks either.
 if test $enable_obsolete_api = 0; then enable_xcrypt_compat_files=0; fi

--- a/test/des-obsolete.c
+++ b/test/des-obsolete.c
@@ -16,8 +16,10 @@
 #include <errno.h>
 #endif
 
+#if HAVE_SYMVER
 symver_ref("encrypt", encrypt, SYMVER_FLOOR);
 symver_ref("setkey", setkey, SYMVER_FLOOR);
+#endif
 
 static void
 expand (unsigned char ex[64], const unsigned char pk[8])

--- a/test/des-obsolete_r.c
+++ b/test/des-obsolete_r.c
@@ -16,8 +16,10 @@
 #include <errno.h>
 #endif
 
+#if HAVE_SYMVER
 symver_ref("encrypt_r", encrypt_r, SYMVER_FLOOR);
 symver_ref("setkey_r", setkey_r, SYMVER_FLOOR);
+#endif
 
 static void
 expand (unsigned char ex[64], const unsigned char pk[8])


### PR DESCRIPTION
Without this change the build was simply broken, if symbol versioning was disabled for any reason, e.g. whether the compiler nor the linker supporting it, or if disabled on purpose by the user.

Also adapt the testsuite and the CI test-matrix.

Fixes #142.