### PR TITLE
Fix warning about signed->unsigned conversion

### DIFF
--- a/lib/alg-yescrypt-opt.c
+++ b/lib/alg-yescrypt-opt.c
@@ -514,7 +514,7 @@ static volatile uint64_t Smask2var = Smask2;
 #define PWXFORM_SIMD(X) { \
 	uint64_t x; \
 	FORCE_REGALLOC_1 \
-	uint32_t lo = (uint32_t)(x = EXTRACT64(X) & Smask2reg); \
+	uint32_t lo = (uint32_t)(x = ((uint64_t)EXTRACT64(X)) & Smask2reg); \
 	FORCE_REGALLOC_2 \
 	uint32_t hi = x >> 32; \
 	X = _mm_mul_epu32(HI32(X), X); \


### PR DESCRIPTION
https://github.com/besser82/libxcrypt/pull/160 didn't fix the sign truncation warning, the wrong set of tests were run. Sorry for the churn, this actually fixes the issue.