### PR TITLE
Remove smartmatch usage from gen-crypt-h

### DIFF
--- a/build-aux/scripts/gen-crypt-h
+++ b/build-aux/scripts/gen-crypt-h
@@ -12,7 +12,6 @@ use v5.14;    # implicit use strict, use feature ':5.14'
 use warnings FATAL => 'all';
 use utf8;
 use open qw(:std :utf8);
-no  if $] >= 5.018, warnings => 'experimental::smartmatch';
 no  if $] >= 5.022, warnings => 'experimental::re_strict';
 use if $] >= 5.022, re       => 'strict';
 
@@ -37,22 +36,20 @@ sub process_config_h {
     local $_;
     while (<$fh>) {
         chomp;
-        # Yes, 'given $_' is really required here.
-        given ($_) {
-            when ('#define HAVE_SYS_CDEFS_H 1') {
-                $have_sys_cdefs_h = 1;
-            }
-            when ('#define HAVE_SYS_CDEFS_BEGIN_END_DECLS 1') {
-                $have_sys_cdefs_begin_end_decls = 1;
-            }
-            when ('#define HAVE_SYS_CDEFS_THROW 1') {
-                $have_sys_cdefs_throw = 1;
-            }
-            when (/^#define PACKAGE_VERSION "((\d+)\.(\d+)\.\d+)"$/) {
-                $substs{XCRYPT_VERSION_STR}   = $1;
-                $substs{XCRYPT_VERSION_MAJOR} = $2;
-                $substs{XCRYPT_VERSION_MINOR} = $3;
-            }
+
+        if ($_ eq '#define HAVE_SYS_CDEFS_H 1') {
+            $have_sys_cdefs_h = 1;
+        }
+        elsif ($_ eq '#define HAVE_SYS_CDEFS_BEGIN_END_DECLS 1') {
+            $have_sys_cdefs_begin_end_decls = 1;
+        }
+        elsif ($_ eq '#define HAVE_SYS_CDEFS_THROW 1') {
+            $have_sys_cdefs_throw = 1;
+        }
+        elsif (/^#define PACKAGE_VERSION "((\d+)\.(\d+)\.\d+)"$/) {
+            $substs{XCRYPT_VERSION_STR}   = $1;
+            $substs{XCRYPT_VERSION_MAJOR} = $2;
+            $substs{XCRYPT_VERSION_MINOR} = $3;
         }
     }
 


### PR DESCRIPTION
This is also needed for building with Perl 5.38... another smartmatch usage that now triggers a deprecation warning.

BTW, it's really a bad idea to treat these warnings all as errors. Otherwise we'd get a warning now, but not a failure... more time to fix stuff...