### PR TITLE
configure: Only text the makecontext signature we need

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -303,13 +303,11 @@ AS_IF([test $ac_cv_header_ucontext_h = yes],
 #include <ucontext.h>
 static int x;
 static void fn1(void) {}
-static void fn2(int a, int b) { x = a - b; }
 ]], [[
   ucontext_t uc1, uc2;
   if (getcontext(&uc1)) return 1;
   if (setcontext(&uc1)) return 1;
   makecontext(&uc1, fn1, 0);
-  makecontext(&uc2, fn2, 2, 1, 1);
   if (swapcontext(&uc1, &uc2)) return 1;
   return x;
 ]])],


### PR DESCRIPTION
The `test/explicit-bzero.c` test uses a start routine without any arguments.  There is no need for the multi-argument version.

This avoids a build failure with glibc and future compilers. The GNU C library declares the `makecontext` callback of type `void (*) (void)`, so no cast is needed.  On other systems, the type may be the (currently distinct) type `void (*) ()`, but given that this only affects the ability to execute a test, no further machinery is added here to detect that different type.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
