### PR TITLE
hardening: negative snprintf return values

### DIFF
--- a/lib/crypt-pbkdf1-sha1.c
+++ b/lib/crypt-pbkdf1-sha1.c
@@ -165,8 +165,10 @@ crypt_sha1crypt_rn (const char *phrase, size_t phr_size,
       hmac_sha1_process_data (hmac_buf, SHA1_SIZE, pwu, pl, hmac_buf);
     }
   /* Now output... */
-  pl = (size_t)snprintf ((char *)output, out_size, "%s%lu$%.*s$",
-                         magic, iterations, (int)sl, setting);
+  dl = snprintf ((char *)output, out_size, "%s%lu$%.*s$",
+                 magic, iterations, (int)sl, setting);
+  assert (dl > 0);
+  pl = (size_t) dl;
   ep = output + pl;
 
   /* Every 3 bytes of hash gives 24 bits which is 4 base64 chars */

--- a/lib/crypt-sunmd5.c
+++ b/lib/crypt-sunmd5.c
@@ -300,8 +300,9 @@ gensalt_sunmd5_rn (unsigned long count,
 
   assert (count != 0);
 
-  size_t written = (size_t) snprintf ((char *)output, o_size,
-                                      "%s,rounds=%lu$", SUNMD5_PREFIX, count);
+  int written = snprintf ((char *)output, o_size,
+                          "%s,rounds=%lu$", SUNMD5_PREFIX, count);
+  assert (written > 0);
 
 
   write_itoa64_4(output + written + 0, rbytes[2], rbytes[3], rbytes[4]);

--- a/lib/util-gensalt-sha.c
+++ b/lib/util-gensalt-sha.c
@@ -60,8 +60,12 @@ gensalt_sha_rn (char tag, size_t maxsalt, unsigned long defcount,
       written = 3;
     }
   else
-    written = (size_t) snprintf ((char *)output, output_size,
-                                 "$%c$rounds=%lu$", tag, count);
+    {
+      int w = snprintf ((char *)output, output_size,
+                        "$%c$rounds=%lu$", tag, count);
+      assert (w > 0);
+      written = (size_t) w;
+    }
 
   /* The length calculation above should ensure that this is always true.  */
   assert (written + 5 < output_size);


### PR DESCRIPTION
snprintf returns negative values in case of errors, as found out by SAST (Static Application Security Testing)