### PR TITLE
crypt-bcrypt.c: Fix Werror=strict-overflow

### DIFF
--- a/lib/crypt-bcrypt.c
+++ b/lib/crypt-bcrypt.c
@@ -433,7 +433,7 @@ BF_encode (unsigned char *dst, const BF_word * src, int size)
       c1 = *sptr++;
       *dptr++ = BF_itoa64[c1 >> 2];
       c1 = (c1 & 0x03) << 4;
-      if (sptr >= end)
+      if (end - sptr <= 0)
         {
           *dptr++ = BF_itoa64[c1];
           break;
@@ -443,7 +443,7 @@ BF_encode (unsigned char *dst, const BF_word * src, int size)
       c1 |= c2 >> 4;
       *dptr++ = BF_itoa64[c1];
       c1 = (c2 & 0x0f) << 2;
-      if (sptr >= end)
+      if (end - sptr <= 0)
         {
           *dptr++ = BF_itoa64[c1];
           break;
@@ -454,7 +454,7 @@ BF_encode (unsigned char *dst, const BF_word * src, int size)
       *dptr++ = BF_itoa64[c1];
       *dptr++ = BF_itoa64[c2 & 0x3f];
     }
-  while (sptr < end);
+  while (end - sptr > 0);
 }
 
 #if XCRYPT_USE_BIGENDIAN


### PR DESCRIPTION
Follow https://github.com/besser82/libxcrypt/commit/502c671e9115f147a6316191459afa55ab2f5345 on https://github.com/besser82/libxcrypt/blob/v4.4.36/lib/crypt-des.c#L117-L138, update https://github.com/besser82/libxcrypt/blob/v4.4.36/lib/crypt-bcrypt.c#L436-L457 too.