### PR TITLE
NEWS: fix current version to be 4.4.38

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,7 @@ libxcrypt NEWS -- history of user-visible changes.
 Please send bug reports, questions and suggestions to
 <https://github.com/besser82/libxcrypt/issues>.
 
-Version 4.4.37
+Version 4.4.38
 
 Version 4.4.37
 * Several fixes to the manpages (issue #185).


### PR DESCRIPTION
Without the change tarball autogeneration fails when ran as is:

    $ make dist
    ...
    NEWS not updated; not releasing