### PR TITLE
Fix github actions.

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,14 +7,14 @@ on:
 jobs:
   skip_duplicates:
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
         # pin to unreleased SHA so we can use 'same_content_newer'
         # see https://github.com/fkirc/skip-duplicate-actions/pull/112
-        uses: fkirc/skip-duplicate-actions@98d1dc89f43a47f8e4fba8e1c1fb8d6c5fc515ee
+        uses: fkirc/skip-duplicate-actions@v5
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
@@ -25,7 +25,7 @@ jobs:
     needs: skip_duplicates
     if: ${{ needs.skip_duplicates.outputs.should_skip != 'true' }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
@@ -44,6 +44,7 @@ jobs:
           - "--enable-obsolete-api --disable-failure-tokens --enable-hashes=descrypt"
 
     env:
+      ac_cv_func_arc4random_buf: "no"
       CC: ${{ matrix.compiler }}
       CONFIG_OPTS: ${{ matrix.config_opts }}
       CFLAGS: "-O0 -g -fprofile-arcs -ftest-coverage"
@@ -53,11 +54,11 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install packages
       run: |
-        packages="lcov"
+        packages="lcov libltdl-dev"
         if [ "$CC" = clang ]; then
           # need 'llvm' for llvm-cov, as well as clang
           packages="$packages clang llvm"
@@ -73,7 +74,7 @@ jobs:
 
     - name: Cache bootstrap
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           INSTALL
@@ -109,10 +110,12 @@ jobs:
       run: ./build-aux/ci/summarize-coverage coverage.info
 
     - name: Upload coverage data to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
         files: coverage.info
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true
 
     - name: Detailed error logs
       if: failure()

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,14 +9,14 @@ on:
 jobs:
   skip_duplicates:
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
         # pin to unreleased SHA so we can use 'same_content_newer'
         # see https://github.com/fkirc/skip-duplicate-actions/pull/112
-        uses: fkirc/skip-duplicate-actions@98d1dc89f43a47f8e4fba8e1c1fb8d6c5fc515ee
+        uses: fkirc/skip-duplicate-actions@v5
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
@@ -27,7 +27,7 @@ jobs:
     needs: skip_duplicates
     if: ${{ needs.skip_duplicates.outputs.should_skip != 'true' }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read
@@ -35,10 +35,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+
+    - name: Install packages
+      run: sudo apt-get install libltdl-dev
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         # CodeQL lumps C with C++.  Perl is not currently supported.
         languages: cpp, python
@@ -60,7 +63,7 @@ jobs:
 
     - name: Cache bootstrap
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           INSTALL
@@ -90,7 +93,7 @@ jobs:
         make -j${{ env.NPROCS }} test-programs
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
 
     - name: Detailed error logs
       if: failure()

--- a/.github/workflows/config-matrix.yml
+++ b/.github/workflows/config-matrix.yml
@@ -7,14 +7,14 @@ on:
 jobs:
   skip_duplicates:
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
         # pin to unreleased SHA so we can use 'same_content_newer'
         # see https://github.com/fkirc/skip-duplicate-actions/pull/112
-        uses: fkirc/skip-duplicate-actions@98d1dc89f43a47f8e4fba8e1c1fb8d6c5fc515ee
+        uses: fkirc/skip-duplicate-actions@v5
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
@@ -25,7 +25,7 @@ jobs:
     needs: skip_duplicates
     if: ${{ needs.skip_duplicates.outputs.should_skip != 'true' }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
@@ -76,11 +76,15 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install packages
-      if: ${{ matrix.compiler == 'clang' }}
-      run: sudo apt-get install clang
+      run: |
+        packages="libltdl-dev"
+        if [ "$CC" = clang ]; then
+          packages="$packages clang"
+        fi
+        sudo apt-get install $packages
 
     - name: Versions of build tools
       id: build-tools
@@ -91,7 +95,7 @@ jobs:
 
     - name: Cache bootstrap
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           INSTALL

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Coverity:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     env:
       CVT_PROJECT: besser82/libxcrypt
@@ -57,7 +57,10 @@ jobs:
         fi
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+
+    - name: Install packages
+      run: sudo apt-get install libltdl-dev
 
     - name: Download Coverity Build Tool
       env:
@@ -92,7 +95,7 @@ jobs:
 
     - name: Cache bootstrap
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           INSTALL

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -9,14 +9,12 @@ on:
 jobs:
   skip_duplicates:
     # continue-on-error: true # Uncomment once integration is finished
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        # pin to unreleased SHA so we can use 'same_content_newer'
-        # see https://github.com/fkirc/skip-duplicate-actions/pull/112
-        uses: fkirc/skip-duplicate-actions@98d1dc89f43a47f8e4fba8e1c1fb8d6c5fc515ee
+        uses: fkirc/skip-duplicate-actions@v5
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
@@ -27,7 +25,7 @@ jobs:
     needs: skip_duplicates
     if: ${{ needs.skip_duplicates.outputs.should_skip != 'true' }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
@@ -37,7 +35,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+
+    - name: Install packages
+      run: sudo apt-get install libltdl-dev
 
       # The distcheck build is run with the oldest version of perl we support,
       # in order to verify that we still support it.
@@ -67,7 +68,7 @@ jobs:
 
     - name: Cache bootstrap
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           INSTALL

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -7,14 +7,14 @@ on:
 jobs:
   skip_duplicates:
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
         # pin to unreleased SHA so we can use 'same_content_newer'
         # see https://github.com/fkirc/skip-duplicate-actions/pull/112
-        uses: fkirc/skip-duplicate-actions@98d1dc89f43a47f8e4fba8e1c1fb8d6c5fc515ee
+        uses: fkirc/skip-duplicate-actions@v5
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
@@ -25,7 +25,7 @@ jobs:
     needs: skip_duplicates
     if: ${{ needs.skip_duplicates.outputs.should_skip != 'true' }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
@@ -38,10 +38,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install packages
-      run: sudo apt-get install clang valgrind
+      run: sudo apt-get install clang libltdl-dev valgrind
 
     - name: Versions of build tools
       id: build-tools
@@ -52,7 +52,7 @@ jobs:
 
     - name: Cache bootstrap
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           INSTALL
@@ -92,7 +92,7 @@ jobs:
     needs: skip_duplicates
     if: ${{ needs.skip_duplicates.outputs.should_skip != 'true' }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
@@ -106,11 +106,15 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install packages
-      if: ${{ matrix.compiler == 'clang' }}
-      run: sudo apt-get install clang
+      run: |
+        packages="libltdl-dev"
+        if [ "$CC" = clang ]; then
+          packages="$packages clang"
+        fi
+        sudo apt-get install $packages
 
     - name: Versions of build tools
       id: build-tools
@@ -118,7 +122,7 @@ jobs:
 
     - name: Cache bootstrap
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           INSTALL

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,6 +13,7 @@ create_pr: True
 
 actions:
   post-upstream-clone: "wget https://src.fedoraproject.org/rpms/libxcrypt/raw/main/f/libxcrypt.spec -O libxcrypt.spec"
+  post-modifications: "sed -i -e 's!%bcond_with    bootstrap!%bcond_without bootstrap!g' -e 's!^Patch!#&!g' libxcrypt.spec"
 
 jobs:
 - job: upstream_koji_build

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -177,6 +177,7 @@ perltidyrc = .perltidyrc
 [ControlStructures::ProhibitCStyleForLoops]
 
 [ControlStructures::ProhibitCascadingIfElse]
+max_elsif = 3
 
 [ControlStructures::ProhibitDeepNests]
 

--- a/build-aux/ci/ci-log-dependency-versions
+++ b/build-aux/ci/ci-log-dependency-versions
@@ -75,5 +75,5 @@ except ModuleNotFoundError:
 done
 
 set fnord; shift  # clear $@
-echo "::set-output name=autotools-ver::$autotools_ver"
+echo "autotools-ver=$autotools_ver" >> $GITHUB_OUTPUT
 exit 0

--- a/build-aux/ci/configure-wrapper
+++ b/build-aux/ci/configure-wrapper
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-export DEB_BUILD_MAINT_OPTIONS="${DEB_BUILD_MAINT_OPTIONS:-hardening=+all}"
+export DEB_BUILD_MAINT_OPTIONS="${DEB_BUILD_MAINT_OPTIONS:-hardening=+all optimize=-lto}"
 
 export CPPFLAGS="${CPPFLAGS} $(dpkg-buildflags --get CPPFLAGS)"
 export CFLAGS="${CFLAGS} $(dpkg-buildflags --get CFLAGS)"
 export CXXFLAGS="${CXXFLAGS} $(dpkg-buildflags --get CXXFLAGS)"
 export LDFLAGS="${LDFLAGS} $(dpkg-buildflags --get LDFLAGS)"
+
+# Pretend there is no arc4random_buf available on the system.
+export ac_cv_func_arc4random_buf=no
 
 $PWD/configure "$@"

--- a/build-aux/ci/summarize-coverage
+++ b/build-aux/ci/summarize-coverage
@@ -15,10 +15,10 @@ set -x
 # Merge all of the gcov output into one overview file using lcov,
 # then prune data for the tests themselves, and for system libraries.
 
-lcov --gcov-tool "$GCOV" --rc lcov_branch_coverage=1 \
+lcov --gcov-tool "$GCOV" --rc branch_coverage=1 \
      --directory . --output-file "$unpruned" \
      --capture
 
-lcov --gcov-tool "$GCOV" --rc lcov_branch_coverage=1 \
-     --directory . --output-file "$1" \
-     --remove "$unpruned" '/usr/*' '*test*'
+lcov --gcov-tool "$GCOV" --rc branch_coverage=1 \
+     --directory . --output-file "$1" --ignore-errors unused \
+     --remove "$unpruned" '/usr/*' '*test*' '*gen-des-tables*'

--- a/build-aux/scripts/BuildCommon.pm
+++ b/build-aux/scripts/BuildCommon.pm
@@ -521,16 +521,13 @@ sub parse_symver_args {
         if (/^SYMVER_MIN=(.+)$/) {
             $usage_error->() if defined $SYMVER_MIN;
             $SYMVER_MIN = $1;
-        }
-        elsif (/^SYMVER_FLOOR=(.+)$/) {
+        } elsif (/^SYMVER_FLOOR=(.+)$/) {
             $usage_error->() if defined $SYMVER_FLOOR;
             $SYMVER_FLOOR = $1;
-        }
-        elsif (/^COMPAT_ABI=(.+)$/) {
+        } elsif (/^COMPAT_ABI=(.+)$/) {
             $usage_error->() if defined $COMPAT_ABI;
             $COMPAT_ABI = $1;
-        }
-        else {
+        } else {
             $usage_error->() if defined $map_in;
             $map_in = $_;
         }

--- a/build-aux/scripts/gen-crypt-h
+++ b/build-aux/scripts/gen-crypt-h
@@ -39,14 +39,11 @@ sub process_config_h {
 
         if ($_ eq '#define HAVE_SYS_CDEFS_H 1') {
             $have_sys_cdefs_h = 1;
-        }
-        elsif ($_ eq '#define HAVE_SYS_CDEFS_BEGIN_END_DECLS 1') {
+        } elsif ($_ eq '#define HAVE_SYS_CDEFS_BEGIN_END_DECLS 1') {
             $have_sys_cdefs_begin_end_decls = 1;
-        }
-        elsif ($_ eq '#define HAVE_SYS_CDEFS_THROW 1') {
+        } elsif ($_ eq '#define HAVE_SYS_CDEFS_THROW 1') {
             $have_sys_cdefs_throw = 1;
-        }
-        elsif (/^#define PACKAGE_VERSION "((\d+)\.(\d+)\.\d+)"$/) {
+        } elsif (/^#define PACKAGE_VERSION "((\d+)\.(\d+)\.\d+)"$/) {
             $substs{XCRYPT_VERSION_STR}   = $1;
             $substs{XCRYPT_VERSION_MAJOR} = $2;
             $substs{XCRYPT_VERSION_MINOR} = $3;

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - "lib/gen-des-tables.c"
+  - "test"
+  - "/usr/**/*"


### PR DESCRIPTION
* Update github actions to latest revisions.
* Explicitly use Ubuntu 24.04 image for github actions.
* Install libltdl-dev, as this is needed for bootstrapping.
* Adaptions for lcov-2.0.
* Add codecov.yml configuration.
* Disable the use of arc4random_buf.
* Disable LTO flags.
* Use environment file instead of set-output command.
* Allow cascading if-elsif chain for up to 3 in perlcriticrc.
* Apply selected fixes from perltidy to Perl scripts.

* packit: Ignore gpg-signature and drop downstream applied patches.