### PR TITLE
Fixes for Issue #204.

### DIFF
--- a/lib/crypt.c
+++ b/lib/crypt.c
@@ -181,6 +181,8 @@ do_crypt (const char *phrase, const char *setting, struct crypt_data *data)
             cint->alg_specific, sizeof cint->alg_specific);
 
   explicit_bzero (data->internal, sizeof data->internal);
+  explicit_bzero (data->reserved, sizeof data->reserved);
+  data->initialized = 0;
 }
 
 #if INCLUDE_crypt_rn

--- a/test/short-outbuf.c
+++ b/test/short-outbuf.c
@@ -76,6 +76,42 @@ main (void)
       printf ("Test %zu.1: %s, expected: \"%-2s\", got: \"%-2s\"\n",
               s, result, testcases[i].exp_ra, outbuf);
 
+      j = -1;
+
+      crypt_ra ("@@", "@@", (void **) &outbuf, &j);
+
+      if (!strncmp (testcases[i].exp_ra, outbuf, strlen(outbuf)))
+        {
+          strcpy (result, "PASS");
+        }
+      else
+        {
+          strcpy (result, "FAIL");
+          ok = false;
+        }
+
+      printf ("Test %zu.2: %s, expected: \"%-2s\", got: \"%-2s\"\n",
+              s, result, testcases[i].exp_ra, outbuf);
+
+      free (outbuf);
+      outbuf = NULL;
+      j = sizeof (struct crypt_data);
+
+      crypt_ra ("@@", "@@", (void **) &outbuf, &j);
+
+      if (!strncmp (testcases[i].exp_ra, outbuf, strlen(outbuf)))
+        {
+          strcpy (result, "PASS");
+        }
+      else
+        {
+          strcpy (result, "FAIL");
+          ok = false;
+        }
+
+      printf ("Test %zu.3: %s, expected: \"%-2s\", got: \"%-2s\"\n",
+              s, result, testcases[i].exp_ra, outbuf);
+
       free (outbuf);
     }
 


### PR DESCRIPTION
* crypt: Zeroize initialized and reserved data members after computation.
* crypt: Zeroize and initialize (re)allocated memory in crypt_ra.
* test/short-outbuf: Add two more cases for crypt_ra.