### PR TITLE
yescrypt: Use AVX512VL XOP-like bit rotates for faster Salsa20

### DIFF
--- a/lib/alg-yescrypt-opt.c
+++ b/lib/alg-yescrypt-opt.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright 2009 Colin Percival
- * Copyright 2012-2018 Alexander Peslyak
+ * Copyright 2012-2025 Alexander Peslyak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,6 +47,8 @@
 #if 0
 #ifdef __XOP__
 #warning "Note: XOP is enabled.  That's great."
+#elif defined(__AVX512VL__)
+#warning "Note: AVX512VL is enabled.  That's great."
 #elif defined(__AVX__)
 #warning "Note: AVX is enabled, which is great for classic scrypt and YESCRYPT_WORM, but is sometimes slightly slower than plain SSE2 for YESCRYPT_RW"
 #elif defined(__SSE2__)
@@ -81,6 +83,8 @@
 #include <emmintrin.h>
 #ifdef __XOP__
 #include <x86intrin.h>
+#elif defined(__AVX512VL__)
+#include <immintrin.h>
 #endif
 #elif defined(__SSE__)
 #include <xmmintrin.h>
@@ -179,6 +183,9 @@ static inline void salsa20_simd_unshuffle(const salsa20_blk_t *Bin,
 #ifdef __XOP__
 #define ARX(out, in1, in2, s) \
 	out = _mm_xor_si128(out, _mm_roti_epi32(_mm_add_epi32(in1, in2), s));
+#elif defined(__AVX512VL__)
+#define ARX(out, in1, in2, s) \
+	out = _mm_xor_si128(out, _mm_rol_epi32(_mm_add_epi32(in1, in2), s));
 #else
 #define ARX(out, in1, in2, s) { \
 	__m128i tmp = _mm_add_epi32(in1, in2); \


### PR DESCRIPTION
This speeds up classic scrypt by up to a third, but yescrypt only very slightly. It also reduces code size.

This would only be enabled in builds that support AVX512VL, which I guess is currently uncommon for libxcrypt (even though CPUs that support it are pretty common by now). So maybe in distros like Gentoo where packages are commonly built from source for the local machine?

It shouldn't hurt to have this in the source code anyhow, except that it'd not be part of usual coverage testing - so I suggest occasional testing of a `-march=native` build on a recent CPU, which would be a good idea prior to these changes as well.

I got the same changes into upstream yescrypt, its fork in JtR tree, and yespower earlier today. The AVX512VL code passed tests in all 3 of these on Intel Tiger Lake.

I did not actually test these changes in libxcrypt yet.