### PR TITLE
lib/crypt.c: Do not overwrite the output buffer too early.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ test/crypt-des
 test/crypt-gost-yescrypt
 test/crypt-kat
 test/crypt-md5
+test/crypt-nested-call
 test/crypt-nthash
 test/crypt-pbkdf1-sha1
 test/crypt-scrypt
@@ -87,6 +88,7 @@ test/explicit-bzero
 test/fcrypt-enosys
 test/gensalt
 test/gensalt-bcrypt_x
+test/gensalt-nested-call
 test/gensalt-nthash
 test/gensalt-extradata
 test/getrandom-fallbacks

--- a/Makefile.am
+++ b/Makefile.am
@@ -385,12 +385,14 @@ check_PROGRAMS = \
 	test/compile-strong-alias \
 	test/crypt-badargs \
 	test/crypt-gost-yescrypt \
+	test/crypt-nested-call \
 	test/crypt-sm3-yescrypt \
 	test/crypt-too-long-phrase \
 	test/explicit-bzero \
 	test/gensalt \
 	test/gensalt-bcrypt_x \
 	test/gensalt-extradata \
+	test/gensalt-nested-call \
 	test/gensalt-nthash \
 	test/getrandom-fallbacks \
 	test/getrandom-interface \
@@ -500,12 +502,14 @@ COMMON_TEST_OBJECTS = libcrypt.la
 test_badsalt_LDADD = $(COMMON_TEST_OBJECTS)
 test_badsetting_LDADD = $(COMMON_TEST_OBJECTS)
 test_gensalt_bcrypt_x_LDADD = $(COMMON_TEST_OBJECTS)
+test_gensalt_nested_call_LDADD = $(COMMON_TEST_OBJECTS)
 test_gensalt_nthash_LDADD = $(COMMON_TEST_OBJECTS)
 test_gensalt_extradata_LDADD = $(COMMON_TEST_OBJECTS)
 test_checksalt_LDADD = $(COMMON_TEST_OBJECTS)
 test_des_obsolete_LDADD = $(COMMON_TEST_OBJECTS)
 test_des_obsolete_r_LDADD = $(COMMON_TEST_OBJECTS)
 test_crypt_badargs_LDADD = $(COMMON_TEST_OBJECTS)
+test_crypt_nested_call_LDADD = $(COMMON_TEST_OBJECTS)
 test_crypt_too_long_phrase_LDADD = $(COMMON_TEST_OBJECTS)
 test_preferred_method_LDADD = $(COMMON_TEST_OBJECTS)
 test_short_outbuf_LDADD = $(COMMON_TEST_OBJECTS)

--- a/doc/crypt.3
+++ b/doc/crypt.3
@@ -221,6 +221,12 @@ which will be overwritten by subsequent calls to
 It is not safe to call
 .Nm crypt
 from multiple threads simultaneously.
+It's also not recommended to use the pointer
+returned as an argument for another call to
+.Nm crypt ,
+as some implementations, including earlier
+releases of libxcrypt, may overwrite the underlying
+static output buffer before computing the hash.
 .Pp
 .Nm crypt_r ,
 .Nm crypt_rn ,
@@ -235,6 +241,35 @@ It is safe to call them from multiple threads simultaneously,
 as long as a separate
 .Fa data
 object is used for each thread.
+It's also not recommended to use the pointer
+returned as an argument for another call to
+.Nm crypt_r ,
+.Nm crypt_rn ,
+and
+.Nm crypt_ra
+using the same
+.Fa data
+object for subsequent calls, as some implementations,
+including earlier releases of libxcrypt, may overwrite the
+.Fa output
+field of the passed
+.Fa data
+argument before computing the hash.
+Calling
+.Nm crypt_ra
+with the
+.Fa phrase
+and/or
+.Fa setting
+parameters located within a passed
+.Fa data
+object which is smaller than the size of
+.Vt "struct crypt_data"
+is not recommended, as some implementations, including
+earlier releases of libxcrypt, may not preserve the
+passed literals, if the
+.Fa data
+object needs to be altered.
 .Pp
 Upon error,
 .Nm crypt_r ,

--- a/doc/crypt_gensalt.3
+++ b/doc/crypt_gensalt.3
@@ -135,6 +135,12 @@ which will be overwritten by subsequent calls to
 It is not safe to call
 .Nm crypt_gensalt
 from multiple threads simultaneously.
+It's also not recommended to use the pointer
+returned as an argument for another call to
+.Nm crypt_gensalt ,
+as some implementations, including earlier
+releases of libxcrypt, may overwrite the underlying
+static output buffer before computing the setting.
 However, it
 .Em is
 safe to pass the string returned by
@@ -153,6 +159,14 @@ bytes of storage available.
 .Fa output_size
 should be greater than or equal to
 .Dv CRYPT_GENSALT_OUTPUT_SIZE .
+It's also not recommended to use the pointer
+returned as an argument for another call to
+.Nm crypt_gensalt_rn
+using the same
+.Fa output
+buffer for subsequent calls, as some implementations,
+including earlier releases of libxcrypt, may overwrite
+the supplied buffer before computing the setting.
 .Pp
 .Nm crypt_gensalt_ra
 allocates memory for its result using

--- a/lib/util-make-failure-token.c
+++ b/lib/util-make-failure-token.c
@@ -24,12 +24,14 @@ make_failure_token (const char *setting, char *output, int size)
 {
   if (size >= 3)
     {
-      output[0] = '*';
-      output[1] = '0';
-      output[2] = '\0';
+      char token[3] = "*0";
 
       if (setting && setting[0] == '*' && setting[1] == '0')
-        output[1] = '1';
+        token[1] = '1';
+
+      output[0] = token[0];
+      output[1] = token[1];
+      output[2] = '\0';
     }
 
   /* If there's not enough space for the full failure token, do the

--- a/test/crypt-nested-call.c
+++ b/test/crypt-nested-call.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2025 Björn Esser <besser82 at fedoraproject.org>
+ * All rights reserved.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "crypt-port.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+#define PASSW "alexander"
+
+static const char *settings[] =
+{
+#if INCLUDE_descrypt
+  "Mp",
+#endif
+#if INCLUDE_bigcrypt
+  "Mp............",
+#endif
+#if INCLUDE_bsdicrypt
+  "_J9..MJHn",
+#endif
+#if INCLUDE_md5crypt
+  "$1$MJHnaAke",
+#endif
+#if INCLUDE_nt
+  "$3$",
+#endif
+#if INCLUDE_sunmd5
+  "$md5$BPm.fm03$",
+#endif
+#if INCLUDE_sm3crypt
+  "$sm3$MJHnaAkegEVYHsFK",
+#endif
+#if INCLUDE_sha1crypt
+  "$sha1$248488$ggu.H673kaZ5$",
+#endif
+#if INCLUDE_sha256crypt
+  "$5$MJHnaAkegEVYHsFK",
+#endif
+#if INCLUDE_sha512crypt
+  "$6$MJHnaAkegEVYHsFK",
+#endif
+#if INCLUDE_bcrypt_a
+  "$2a$05$UBVLHeMpJ/QQCv3XqJx8zO",
+#endif
+#if INCLUDE_bcrypt
+  "$2b$05$UBVLHeMpJ/QQCv3XqJx8zO",
+#endif
+#if INCLUDE_bcrypt_y
+  "$2y$05$UBVLHeMpJ/QQCv3XqJx8zO",
+#endif
+#if INCLUDE_bcrypt_x
+  "$2x$05$UBVLHeMpJ/QQCv3XqJx8zO",
+#endif
+#if INCLUDE_yescrypt
+  "$y$j9T$MJHnaAkegEVYHsFKkmfzJ1",
+#endif
+#if INCLUDE_scrypt
+  "$7$CU..../....MJHnaAkegEVYHsFKkmfzJ1",
+#endif
+#if INCLUDE_gost_yescrypt
+  "$gy$j9T$MJHnaAkegEVYHsFKkmfzJ1",
+#endif
+#if INCLUDE_sm3_yescrypt
+  "$sm3y$j9T$MJHnaAkegEVYHsFKkmfzJ1",
+#endif
+};
+
+int
+main (void)
+{
+  char *retval = NULL;
+  int status = 0;
+  struct crypt_data cd;
+  struct crypt_data *p = &cd;
+  int cd_size = (int) sizeof (cd);
+
+  for (size_t i = 0; i < ARRAY_SIZE (settings); i++)
+    {
+      retval = crypt (PASSW, settings[i]);
+      retval = crypt (PASSW, retval);
+
+      if (!retval || *retval == '*')
+        {
+          printf ("Subsequent call to crypt(3) with output as setting "
+                  "failed for prefix \"%s\".\n",
+                  settings[i]);
+          status = 1;
+        }
+
+      // coverity[var_deref_model]
+      retval = crypt (retval, settings[i]);
+
+      if (!retval || *retval == '*')
+        {
+          printf ("Subsequent call to crypt(3) with output as key "
+                  "failed for prefix \"%s\".\n",
+                  settings[i]);
+          status = 1;
+        }
+
+      retval = crypt_r (PASSW, settings[i], p);
+      retval = crypt_r (PASSW, retval, p);
+
+      if (!retval || *retval == '*')
+        {
+          printf ("Subsequent call to crypt_r(3) with output as setting "
+                  "failed for prefix \"%s\".\n",
+                  settings[i]);
+          status = 1;
+        }
+
+      retval = crypt_r (retval, settings[i], p);
+
+      if (!retval || *retval == '*')
+        {
+          printf ("Subsequent call to crypt_r(3) with output as key "
+                  "failed for prefix \"%s\".\n",
+                  settings[i]);
+          status = 1;
+        }
+
+      retval = crypt_rn (PASSW, settings[i], p, cd_size);
+      retval = crypt_rn (PASSW, retval, p, cd_size);
+
+      if (!retval || *retval == '*')
+        {
+          printf ("Subsequent call to crypt_rn(3) with output as setting "
+                  "failed for prefix \"%s\".\n",
+                  settings[i]);
+          status = 1;
+        }
+
+      retval = crypt_rn (retval, settings[i], p, cd_size);
+
+      if (!retval || *retval == '*')
+        {
+          printf ("Subsequent call to crypt_rn(3) with output as key "
+                  "failed for prefix \"%s\".\n",
+                  settings[i]);
+          status = 1;
+        }
+
+      retval = crypt_ra (PASSW, settings[i], (void **) &p, &cd_size);
+      retval = crypt_ra (PASSW, retval, (void **) &p, &cd_size);
+
+      if (!retval || *retval == '*')
+        {
+          printf ("Subsequent call to crypt_ra(3) with output as setting "
+                  "failed for prefix \"%s\".\n",
+                  settings[i]);
+          status = 1;
+        }
+
+      retval = crypt_ra (retval, settings[i], (void **) &p, &cd_size);
+
+      if (!retval || *retval == '*')
+        {
+          printf ("Subsequent call to crypt_ra(3) with output as key "
+                  "failed for prefix \"%s\".\n",
+                  settings[i]);
+          status = 1;
+        }
+    }
+
+  explicit_bzero (&cd, sizeof cd);
+  return status;
+}

--- a/test/gensalt-nested-call.c
+++ b/test/gensalt-nested-call.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2025 Björn Esser <besser82 at fedoraproject.org>
+ * All rights reserved.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "crypt-port.h"
+
+#if INCLUDE_bcrypt        || INCLUDE_bcrypt_a     || INCLUDE_bcrypt_y    || \
+    INCLUDE_bigcrypt      || INCLUDE_bsdicrypt    || INCLUDE_descrypt    || \
+    INCLUDE_gost_yescrypt || INCLUDE_md5crypt     || INCLUDE_nt          || \
+    INCLUDE_scrypt        || INCLUDE_sha1crypt    || INCLUDE_sha256crypt || \
+    INCLUDE_sha512crypt   || INCLUDE_sm3_yescrypt || INCLUDE_sm3crypt    || \
+    INCLUDE_sunmd5        || INCLUDE_yescrypt
+
+#include <stdio.h>
+
+static const char *prefixes[] =
+{
+#if INCLUDE_descrypt
+  "Mp",
+#endif
+#if INCLUDE_bigcrypt
+  "Mp............",
+#endif
+#if INCLUDE_bsdicrypt
+  "_",
+#endif
+#if INCLUDE_md5crypt
+  "$1$",
+#endif
+#if INCLUDE_nt
+  "$3$",
+#endif
+#if INCLUDE_sunmd5
+  "$md5$",
+#endif
+#if INCLUDE_sm3crypt
+  "$sm3$",
+#endif
+#if INCLUDE_sha1crypt
+  "$sha1$",
+#endif
+#if INCLUDE_sha256crypt
+  "$5$",
+#endif
+#if INCLUDE_sha512crypt
+  "$6$",
+#endif
+#if INCLUDE_bcrypt_a
+  "$2a$",
+#endif
+#if INCLUDE_bcrypt
+  "$2b$",
+#endif
+#if INCLUDE_bcrypt_y
+  "$2y$",
+#endif
+#if INCLUDE_yescrypt
+  "$y$",
+#endif
+#if INCLUDE_scrypt
+  "$7$",
+#endif
+#if INCLUDE_gost_yescrypt
+  "$gy$",
+#endif
+#if INCLUDE_sm3_yescrypt
+  "$sm3y$",
+#endif
+};
+
+int
+main (void)
+{
+  char output[CRYPT_GENSALT_OUTPUT_SIZE];
+  char *retval = NULL;
+  int status = 0;
+
+  for (size_t i = 0; i < ARRAY_SIZE (prefixes); i++)
+    {
+      retval = crypt_gensalt (prefixes[i], 0, NULL, 0);
+      retval = !retval ? 0 : crypt_gensalt (retval, 0, NULL, 0);
+
+      if (!retval)
+        {
+          printf ("Subsequent call to crypt_gensalt(3) failed for prefix \"%s\".\n",
+                  prefixes[i]);
+          status = 1;
+        }
+
+      retval = crypt_gensalt_rn (prefixes[i], 0, NULL, 0,
+                                 output, sizeof output);
+      retval = !retval ? 0 : crypt_gensalt_rn (retval, 0, NULL, 0,
+                                               output, sizeof output);
+
+      if (!retval)
+        {
+          printf ("Subsequent call to crypt_gensalt_rn(3) failed for prefix \"%s\".\n",
+                  prefixes[i]);
+          status = 1;
+        }
+    }
+
+  return status;
+}
+
+#else
+
+int
+main (void)
+{
+  return 77; /* UNSUPPORTED */
+}
+
+#endif /* all, but bcrypt_x only */


### PR DESCRIPTION
Allow passing a pointer returned by crypt(3) previously as the input for a subsequent call to crypt(3), adapt the manpage accordingly, and implement a simple testcase for such a scenario.  This also applies to the other variants of the crypt function, when the same data object is used for	subsequent calls.

Alter the resize process of the data object by crypt_ra(3), to keep the literals passed with the phrase and the setting parameter during the runtime of the function, if those are stored within the initially passed data object.

Also apply the same semantics to the crypt_gensalt(3) function family, and the internally used make_failure_token() helper.

Fixes #209.