### PR TITLE
lib/util-xstrcpy.c: strcpy_or_abort: Actually abort() in -DNDEBUG builds

### DIFF
--- a/lib/util-xstrcpy.c
+++ b/lib/util-xstrcpy.c
@@ -20,6 +20,8 @@
 
 #include "crypt-port.h"
 
+#include <stdlib.h>
+
 /* Provide a safe way to copy strings with the guarantee src,
    including its terminating '\0', will fit d_size bytes.
    The trailing bytes of d_size will be filled with '\0'.
@@ -30,7 +32,9 @@ strcpy_or_abort (void *dst, size_t d_size, const void *src)
   assert (dst != NULL);
   assert (src != NULL);
   size_t s_size = strlen ((const char *)src);
-  assert (d_size >= s_size + 1);
+  assert (d_size > s_size);
+  if (!(d_size > s_size)) /* for NDEBUG builds */
+    abort();
 
   memcpy (dst, src, s_size);
   memset (((char *)dst) + s_size, 0, d_size - s_size);


### PR DESCRIPTION
It's reasonable that it uses `assert` when all of its uses are such that the data must fit, so it'd be a usage bug (which we'd want detected in this way) if the data ever doesn't fit. However, it's probably unexpected that this function becomes unsafe in non-debugging builds. It should probably literally call `abort` when the `assert` condition is not met yet execution "mysteriously" continues. I hope the compiler will optimize out the redundant check when `assert` is compiled in.

Also, the condition may be simplified (in both places) to `d_size > s_size`. I think the compiler cannot perform the same optimization on its own because it has to assume `+ 1` may overflow (wraparound to 0).

This PR is untested.