### PR TITLE
lib/crypt.h: provide list of supported hash algorithms

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -384,6 +384,7 @@ check_PROGRAMS = \
 	test/checksalt \
 	test/compile-strong-alias \
 	test/crypt-badargs \
+	test/crypt-get-supported-hash-methods \
 	test/crypt-gost-yescrypt \
 	test/crypt-nested-call \
 	test/crypt-sm3-yescrypt \
@@ -509,6 +510,7 @@ test_checksalt_LDADD = $(COMMON_TEST_OBJECTS)
 test_des_obsolete_LDADD = $(COMMON_TEST_OBJECTS)
 test_des_obsolete_r_LDADD = $(COMMON_TEST_OBJECTS)
 test_crypt_badargs_LDADD = $(COMMON_TEST_OBJECTS)
+test_crypt_get_supported_hash_methods_LDADD = $(COMMON_TEST_OBJECTS)
 test_crypt_nested_call_LDADD = $(COMMON_TEST_OBJECTS)
 test_crypt_too_long_phrase_LDADD = $(COMMON_TEST_OBJECTS)
 test_preferred_method_LDADD = $(COMMON_TEST_OBJECTS)

--- a/build-aux/scripts/gen-crypt-hashes-h
+++ b/build-aux/scripts/gen-crypt-hashes-h
@@ -110,6 +110,16 @@ EOT
 
 #define HASH_ALGORITHM_DEFAULT "$default_prefix"
 EOT
+
+    # List of supported hash methods
+    my @provided_hashes = ();
+    while (my ($e, $v) = each %{$hconf->hashes}){
+        if ($enabled{$e}) {
+            push @provided_hashes, "$e:@{[$v->prefix]}";
+        }
+    }
+    print "\n#define SUPPORTED_HASH_METHODS \\\n";
+    print '  "' . (join ";\" \\\n  \"", sort @provided_hashes) . '"';
     print <<'EOT';
 
 #endif /* crypt-hashes.h */

--- a/lib/crypt.c
+++ b/lib/crypt.c
@@ -419,3 +419,9 @@ crypt_preferred_method (void)
 }
 SYMVER_crypt_preferred_method;
 #endif
+
+const char *crypt_get_supported_hash_methods(void)
+{
+    return SUPPORTED_HASH_METHODS;
+}
+SYMVER_crypt_get_supported_hash_methods;

--- a/lib/crypt.h.in
+++ b/lib/crypt.h.in
@@ -244,6 +244,11 @@ extern const char *crypt_preferred_method (void);
 /* Version number as a string constant.  */
 #define XCRYPT_VERSION_STR "@XCRYPT_VERSION_STR@"
 
+/* List of provided by the current build hash algorithms*/
+
+#define CRYPT_GET_SUPPORTED_HASH_METHODS_AVAILABLE 1
+extern const char *crypt_get_supported_hash_methods(void);
+
 @END_DECLS@
 
 #endif /* crypt.h */

--- a/lib/libcrypt.map.in
+++ b/lib/libcrypt.map.in
@@ -19,6 +19,7 @@ crypt_gensalt_ra	XCRYPT_2.0	GLIBC_2.0:owl:suse	GLIBC_2.2.2:alt     OW_CRYPT_1.0:
 # Actively supported interfaces from libxcrypt.
 crypt_checksalt		XCRYPT_4.3
 crypt_preferred_method	XCRYPT_4.4
+crypt_get_supported_hash_methods XCRYPT_4.5
 
 # Interfaces for code compatibility with libxcrypt v3.1.1 and earlier.
 # No longer available to new binaries.  Include in version-script, only
@@ -45,4 +46,4 @@ fcrypt			-		GLIBC_2.0
 %chain GLIBC_2.3 GLIBC_2.4 GLIBC_2.12 GLIBC_2.16 GLIBC_2.17 GLIBC_2.18
 %chain GLIBC_2.21 GLIBC_2.27 GLIBC_2.29 GLIBC_2.32 GLIBC_2.33 GLIBC_2.35
 %chain GLIBC_2.36 GLIBC_2.38
-%chain OW_CRYPT_1.0 XCRYPT_2.0 XCRYPT_4.3 XCRYPT_4.4
+%chain OW_CRYPT_1.0 XCRYPT_2.0 XCRYPT_4.3 XCRYPT_4.4 XCRYPT_4.5

--- a/test/crypt-get-supported-hash-methods.c
+++ b/test/crypt-get-supported-hash-methods.c
@@ -1,0 +1,76 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "crypt-port.h"
+
+const char defined_hash_methods[] =
+#if INCLUDE_bcrypt
+  "bcrypt:$2b$;"
+#endif
+#if INCLUDE_bcrypt_a
+  "bcrypt_a:$2a$;"
+#endif
+#if INCLUDE_bcrypt_x
+  "bcrypt_x:$2x$;"
+#endif
+#if INCLUDE_bcrypt_y
+  "bcrypt_y:$2y$;"
+#endif
+#if INCLUDE_bigcrypt
+  "bigcrypt:;"
+#endif
+#if INCLUDE_bsdicrypt
+  "bsdicrypt:_;"
+#endif
+#if INCLUDE_descrypt
+  "descrypt:;"
+#endif
+#if INCLUDE_gost_yescrypt
+  "gost_yescrypt:$gy$;"
+#endif
+#if INCLUDE_md5crypt
+  "md5crypt:$1$;"
+#endif
+#if INCLUDE_nt
+  "nt:$3$;"
+#endif
+#if INCLUDE_scrypt
+  "scrypt:$7$;"
+#endif
+#if INCLUDE_sha1crypt
+  "sha1crypt:$sha1;"
+#endif
+#if INCLUDE_sha256crypt
+  "sha256crypt:$5$;"
+#endif
+#if INCLUDE_sha512crypt
+  "sha512crypt:$6$;"
+#endif
+#if INCLUDE_sm3_yescrypt
+  "sm3_yescrypt:$sm3y$;"
+#endif
+#if INCLUDE_sm3crypt
+  "sm3crypt:$sm3$;"
+#endif
+#if INCLUDE_sunmd5
+  "sunmd5:$md5;"
+#endif
+#if INCLUDE_yescrypt
+  "yescrypt:$y$;"
+#endif
+"";
+
+int main(void)
+{
+    const char *expected = defined_hash_methods;
+    const char *reported = crypt_get_supported_hash_methods();
+    size_t len1 = strlen(expected) - 1, len2 = strlen(reported);
+    int res = (len1 != len2 || strncmp(expected, reported, len2));
+
+    // Assume there is ";" in the end of defined_hash_methods
+    fprintf(stderr, "Compiled and reported by"
+            " crypt_get_supported_hash_methods() lists of supported"
+            " hash methods are %sequal:\n\"%s\" %s=\n\"%s;\"\n",
+            (res ? "NOT " : ""), expected, (res ? "!" : "="), reported);
+    return res;
+}


### PR DESCRIPTION
IMHO, it might be useful for users to get a list of hashing algorithms supported by the current build. I decided to use a dictionary-like structure so that users could match the algorithm name with the corresponding prefix.

So, I think, user can iterate over this list until they get {NULL, NULL}:
https://github.com/altlinux/pyxcrypt/commit/c56c9dba3fe6a2518db5919c1fb7e1c95c4e039b#diff-43dec635b9590d1a1e5874610e291500ffc204b411a10313a60d099106452f47R126

But they will have to check if the linked version of libxcrypt is higher than some value (where this list was implemented). Or libxcrypt can also provide some var to check with ```#ifdef```
