### PR TITLE
fix -Werror=discarded-qualifiers

### DIFF
--- a/lib/crypt-gost-yescrypt.c
+++ b/lib/crypt-gost-yescrypt.c
@@ -131,7 +131,7 @@ crypt_gost_yescrypt_rn (const char *phrase, size_t phr_size,
   intbuf->outbuf[1] = 'g';
 
   /* extract yescrypt output from "$y$param$salt$output" */
-  char *hptr = strchr ((const char *) intbuf->retval + 3, '$');
+  char *hptr = strchr ((char *) intbuf->retval + 3, '$');
   if (!hptr)
     {
       errno = EINVAL;

--- a/lib/crypt-sm3-yescrypt.c
+++ b/lib/crypt-sm3-yescrypt.c
@@ -136,7 +136,7 @@ crypt_sm3_yescrypt_rn (const char *phrase, size_t phr_size,
   intbuf->outbuf[3] = '3';
 
   /* extract yescrypt output from "$y$param$salt$output" */
-  char *hptr = strchr ((const char *) intbuf->retval + 3, '$');
+  char *hptr = strchr ((char *) intbuf->retval + 3, '$');
   if (!hptr)
     {
       errno = EINVAL;


### PR DESCRIPTION
On Fedora rawhide (to be Fedora 44), gcc became more strict wrt. const-ness.