### PR TITLE
lib/crypt-sha*, lib/crypt-sm3: fix misleading comment

### DIFF
--- a/lib/crypt-sha256.c
+++ b/lib/crypt-sha256.c
@@ -212,7 +212,8 @@ crypt_sha256crypt_rn (const char *phrase, size_t phr_size,
   /* Start computation of S byte sequence.  */
   SHA256_Init (ctx);
 
-  /* For every character in the password add the entire password.  */
+  /* Add the salt n times where n is the value of the first byte of the
+     intermediate result plus 16.  */
   for (cnt = 0; cnt < (size_t) 16 + (size_t) result[0]; ++cnt)
     SHA256_Update (ctx, salt, salt_size);
 

--- a/lib/crypt-sha512.c
+++ b/lib/crypt-sha512.c
@@ -214,7 +214,8 @@ crypt_sha512crypt_rn (const char *phrase, size_t phr_size,
   /* Start computation of S byte sequence.  */
   SHA512_Init (ctx);
 
-  /* For every character in the password add the entire password.  */
+  /* Add the salt n times where n is the value of the first byte of the
+     intermediate result plus 16.  */
   for (cnt = 0; cnt < (size_t) 16 + (size_t) result[0]; ++cnt)
     SHA512_Update (ctx, salt, salt_size);
 

--- a/lib/crypt-sm3.c
+++ b/lib/crypt-sm3.c
@@ -213,7 +213,8 @@ crypt_sm3crypt_rn (const char *phrase, size_t phr_size,
   /* Start computation of S byte sequence.  */
   sm3_init (ctx);
 
-  /* For every character in the password add the entire password.  */
+  /* Add the salt n times where n is the value of the first byte of the
+     intermediate result plus 16.  */
   for (cnt = 0; cnt < (size_t) 16 + (size_t) result[0]; ++cnt)
     sm3_update (ctx, salt, salt_size);
 


### PR DESCRIPTION
A copied comment misrepresents the calculation step of the S byte sequence in the crypt algorithms based on SHA2 and sm3. Replace it with an actual description of what is happening.